### PR TITLE
Expand support for handling several code lay-out options

### DIFF
--- a/src/LivingDocumentation.Abstractions/Modifier.cs
+++ b/src/LivingDocumentation.Abstractions/Modifier.cs
@@ -11,5 +11,12 @@ public enum Modifier
     Abstract    = 1 << 5,
     Override    = 1 << 6,
     Readonly    = 1 << 7,
-    Async       = 1 << 8
+    Async       = 1 << 8,
+    Const       = 1 << 9,
+    Sealed      = 1 << 10,
+    Virtual     = 1 << 11,
+    Extern      = 1 << 12,
+    New         = 1 << 13,
+    Unsafe      = 1 << 14,
+    Partial     = 1 << 15,
 }

--- a/src/LivingDocumentation.Analyzer/Analyzers/BranchingAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/BranchingAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 internal class BranchingAnalyzer : CSharpSyntaxWalker

--- a/src/LivingDocumentation.Analyzer/Analyzers/BranchingAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/BranchingAnalyzer.cs
@@ -2,96 +2,95 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+internal class BranchingAnalyzer : CSharpSyntaxWalker
 {
-    internal class BranchingAnalyzer : CSharpSyntaxWalker
+    private readonly SemanticModel semanticModel;
+    private readonly List<Statement> statements;
+
+    public BranchingAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
     {
-        private readonly SemanticModel semanticModel;
-        private readonly List<Statement> statements;
+        this.semanticModel = semanticModel;
+        this.statements = statements;
+    }
 
-        public BranchingAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
+    public override void VisitIfStatement(IfStatementSyntax node)
+    {
+        var ifStatement = new If();
+        this.statements.Add(ifStatement);
+
+        var ifSection = new IfElseSection();
+        ifStatement.Sections.Add(ifSection);
+
+        ifSection.Condition = node.Condition.ToString();
+
+        var ifInvocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, ifSection.Statements);
+        ifInvocationAnalyzer.Visit(node.Statement);
+
+        var elseNode = node.Else;
+        while (elseNode != null)
         {
-            this.semanticModel = semanticModel;
-            this.statements = statements;
-        }
+            var section = new IfElseSection();
+            ifStatement.Sections.Add(section);
 
-        public override void VisitIfStatement(IfStatementSyntax node)
-        {
-            var ifStatement = new If();
-            this.statements.Add(ifStatement);
+            var elseInvocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, section.Statements);
+            elseInvocationAnalyzer.Visit(elseNode.Statement);
 
-            var ifSection = new IfElseSection();
-            ifStatement.Sections.Add(ifSection);
-
-            ifSection.Condition = node.Condition.ToString();
-
-            var ifInvocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, ifSection.Statements);
-            ifInvocationAnalyzer.Visit(node.Statement);
-
-            var elseNode = node.Else;
-            while (elseNode != null)
+            if (elseNode.Statement.IsKind(SyntaxKind.IfStatement))
             {
-                var section = new IfElseSection();
-                ifStatement.Sections.Add(section);
+                var elseIfNode = (IfStatementSyntax)elseNode.Statement;
+                section.Condition = elseIfNode.Condition.ToString();
 
-                var elseInvocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, section.Statements);
-                elseInvocationAnalyzer.Visit(elseNode.Statement);
+                elseNode = elseIfNode.Else;
+            }
+            else
+            {
+                elseNode = null;
+            }
+        }
+    }
 
-                if (elseNode.Statement.IsKind(SyntaxKind.IfStatement))
+    public override void VisitSwitchStatement(SwitchStatementSyntax node)
+    {
+        var switchStatement = new Switch();
+        this.statements.Add(switchStatement);
+
+        switchStatement.Expression = node.Expression.ToString();
+
+        foreach (var section in node.Sections)
+        {
+            var switchSection = new SwitchSection();
+            switchStatement.Sections.Add(switchSection);
+
+            switchSection.Labels.AddRange(section.Labels.Select(l => Label(l)));
+
+            var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, switchSection.Statements);
+            invocationAnalyzer.Visit(section);
+        }
+    }
+
+    private static string Label(SwitchLabelSyntax label)
+    {
+        switch (label)
+        {
+            case CasePatternSwitchLabelSyntax casePatternLabel:
+                var condition = casePatternLabel.WhenClause?.Condition?.ToString();
+                if (condition == null)
                 {
-                    var elseIfNode = (IfStatementSyntax)elseNode.Statement;
-                    section.Condition = elseIfNode.Condition.ToString();
-
-                    elseNode = elseIfNode.Else;
+                    return casePatternLabel.Pattern?.ToString();
                 }
-                else
-                {
-                    elseNode = null;
-                }
-            }
-        }
 
-        public override void VisitSwitchStatement(SwitchStatementSyntax node)
-        {
-            var switchStatement = new Switch();
-            this.statements.Add(switchStatement);
+                return $"{casePatternLabel.Pattern} when {condition}";
 
-            switchStatement.Expression = node.Expression.ToString();
+            case CaseSwitchLabelSyntax caseLabel:
+                return caseLabel.Value.ToString();
 
-            foreach (var section in node.Sections)
-            {
-                var switchSection = new SwitchSection();
-                switchStatement.Sections.Add(switchSection);
+            case DefaultSwitchLabelSyntax defaultLabel:
+                return defaultLabel.Keyword.ToString();
 
-                switchSection.Labels.AddRange(section.Labels.Select(l => Label(l)));
-
-                var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, switchSection.Statements);
-                invocationAnalyzer.Visit(section);
-            }
-        }
-
-        private static string Label(SwitchLabelSyntax label)
-        {
-            switch (label)
-            {
-                case CasePatternSwitchLabelSyntax casePatternLabel:
-                    var condition = casePatternLabel.WhenClause?.Condition?.ToString();
-                    if (condition == null)
-                    {
-                        return casePatternLabel.Pattern?.ToString();
-                    }
-
-                    return $"{casePatternLabel.Pattern} when {condition}";
-
-                case CaseSwitchLabelSyntax caseLabel:
-                    return caseLabel.Value.ToString();
-
-                case DefaultSwitchLabelSyntax defaultLabel:
-                    return defaultLabel.Keyword.ToString();
-
-                default:
-                    return label.ToString();
-            }
+            default:
+                return label.ToString();
         }
     }
 }

--- a/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
@@ -2,159 +2,158 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+internal class InvocationsAnalyzer : CSharpSyntaxWalker
 {
-    internal class InvocationsAnalyzer : CSharpSyntaxWalker
+    private readonly SemanticModel semanticModel;
+    private readonly List<Statement> statements;
+
+    public InvocationsAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
     {
-        private readonly SemanticModel semanticModel;
-        private readonly List<Statement> statements;
+        this.semanticModel = semanticModel;
+        this.statements = statements;
+    }
 
-        public InvocationsAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
+    public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+    {
+        string containingType = this.semanticModel.GetTypeDisplayString(node);
+
+        var invocation = new InvocationDescription(containingType, node.Type.ToString());
+        this.statements.Add(invocation);
+
+        if (node.ArgumentList != null)
         {
-            this.semanticModel = semanticModel;
-            this.statements = statements;
+            foreach (var argument in node.ArgumentList.Arguments)
+            {
+                var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), argument.Expression.ToString());
+                invocation.Arguments.Add(argumentDescription);
+            }
         }
 
-        public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+        if (node.Initializer != null)
         {
-            string containingType = this.semanticModel.GetTypeDisplayString(node);
-
-            var invocation = new InvocationDescription(containingType, node.Type.ToString());
-            this.statements.Add(invocation);
-
-            if (node.ArgumentList != null)
+            foreach (var expression in node.Initializer.Expressions)
             {
-                foreach (var argument in node.ArgumentList.Arguments)
-                {
-                    var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), argument.Expression.ToString());
-                    invocation.Arguments.Add(argumentDescription);
-                }
+                var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(expression), expression.ToString());
+                invocation.Arguments.Add(argumentDescription);
             }
-
-            if (node.Initializer != null)
-            {
-                foreach (var expression in node.Initializer.Expressions)
-                {
-                    var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(expression), expression.ToString());
-                    invocation.Arguments.Add(argumentDescription);
-                }
-            }
-
-            base.VisitObjectCreationExpression(node);
         }
 
-        public override void VisitSwitchStatement(SwitchStatementSyntax node)
+        base.VisitObjectCreationExpression(node);
+    }
+
+    public override void VisitSwitchStatement(SwitchStatementSyntax node)
+    {
+        var branchingAnalyzer = new BranchingAnalyzer(this.semanticModel, this.statements);
+        branchingAnalyzer.Visit(node);
+    }
+
+    public override void VisitIfStatement(IfStatementSyntax node)
+    {
+        var branchingAnalyzer = new BranchingAnalyzer(this.semanticModel, this.statements);
+        branchingAnalyzer.Visit(node);
+    }
+
+    public override void VisitForEachStatement(ForEachStatementSyntax node)
+    {
+        var loopingAnalyzer = new LoopingAnalyzer(this.semanticModel, this.statements);
+        loopingAnalyzer.Visit(node);
+    }
+
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        var expression = this.GetExpressionWithSymbol(node);
+
+        if (Program.RuntimeOptions.VerboseOutput && this.semanticModel.GetSymbolInfo(expression).Symbol == null)
         {
-            var branchingAnalyzer = new BranchingAnalyzer(this.semanticModel, this.statements);
-            branchingAnalyzer.Visit(node);
+            Console.WriteLine("WARN: Could not resolve type of invocation of the following block:");
+            Console.WriteLine(node.ToFullString());
+            return;
         }
 
-        public override void VisitIfStatement(IfStatementSyntax node)
+        if (this.semanticModel.GetConstantValue(node).HasValue && string.Equals((node.Expression as IdentifierNameSyntax)?.Identifier.ValueText, "nameof", StringComparison.Ordinal))
         {
-            var branchingAnalyzer = new BranchingAnalyzer(this.semanticModel, this.statements);
-            branchingAnalyzer.Visit(node);
+            // nameof is compiler sugar, and is actually a method we are not interrested in
+            return;
         }
 
-        public override void VisitForEachStatement(ForEachStatementSyntax node)
+        var containingType = this.semanticModel.GetSymbolInfo(expression).Symbol?.ContainingSymbol.ToDisplayString();
+        if (containingType == null)
         {
-            var loopingAnalyzer = new LoopingAnalyzer(this.semanticModel, this.statements);
-            loopingAnalyzer.Visit(node);
+            containingType = this.semanticModel.GetSymbolInfo(expression).CandidateSymbols.FirstOrDefault()?.ContainingSymbol.ToDisplayString();
         }
 
-        public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+        var methodName = string.Empty;
+
+        switch (node.Expression)
         {
-            var expression = this.GetExpressionWithSymbol(node);
+            case MemberAccessExpressionSyntax m:
+                methodName = m.Name.ToString();
+                break;
+            case IdentifierNameSyntax i:
+                methodName = i.Identifier.ValueText;
+                break;
+        }
 
-            if (Program.RuntimeOptions.VerboseOutput && this.semanticModel.GetSymbolInfo(expression).Symbol == null)
-            {
-                Console.WriteLine("WARN: Could not resolve type of invocation of the following block:");
-                Console.WriteLine(node.ToFullString());
-                return;
-            }
-
-            if (this.semanticModel.GetConstantValue(node).HasValue && string.Equals((node.Expression as IdentifierNameSyntax)?.Identifier.ValueText, "nameof", StringComparison.Ordinal))
-            {
-                // nameof is compiler sugar, and is actually a method we are not interrested in
-                return;
-            }
-
-            var containingType = this.semanticModel.GetSymbolInfo(expression).Symbol?.ContainingSymbol.ToDisplayString();
-            if (containingType == null)
-            {
-                containingType = this.semanticModel.GetSymbolInfo(expression).CandidateSymbols.FirstOrDefault()?.ContainingSymbol.ToDisplayString();
-            }
-
-            var methodName = string.Empty;
-
-            switch (node.Expression)
-            {
-                case MemberAccessExpressionSyntax m:
-                    methodName = m.Name.ToString();
-                    break;
-                case IdentifierNameSyntax i:
-                    methodName = i.Identifier.ValueText;
-                    break;
-            }
-
-            var invocation = new InvocationDescription(containingType, methodName);
-            this.statements.Add(invocation);
+        var invocation = new InvocationDescription(containingType, methodName);
+        this.statements.Add(invocation);
 
         foreach (var argument in node.ArgumentList.Arguments)
         {
-                var value = argument.Expression.ResolveValue(this.semanticModel);
+            var value = argument.Expression.ResolveValue(this.semanticModel);
 
-                var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), value);
+            var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), value);
             invocation.Arguments.Add(argumentDescription);
         }
 
-            base.VisitInvocationExpression(node);
-        }
+        base.VisitInvocationExpression(node);
+    }
 
-        private ExpressionSyntax GetExpressionWithSymbol(InvocationExpressionSyntax node)
+    private ExpressionSyntax GetExpressionWithSymbol(InvocationExpressionSyntax node)
+    {
+        var expression = node.Expression;
+
+        if (this.semanticModel.GetSymbolInfo(expression).Symbol == null)
         {
-            var expression = node.Expression;
+            // This might be part of a chain of extention methods (f.e. Fluent API's), the symbols are only available at the beginning of the chain.
+            var pNode = (SyntaxNode)node;
 
-            if (this.semanticModel.GetSymbolInfo(expression).Symbol == null)
+            while (pNode != null && (pNode is not InvocationExpressionSyntax || (pNode is InvocationExpressionSyntax && (this.semanticModel.GetTypeInfo(pNode).Type?.Kind == SymbolKind.ErrorType || this.semanticModel.GetSymbolInfo(expression).Symbol == null))))
             {
-                // This might be part of a chain of extention methods (f.e. Fluent API's), the symbols are only available at the beginning of the chain.
-                var pNode = (SyntaxNode)node;
+                pNode = pNode.Parent;
 
-                while (pNode != null && (pNode is not InvocationExpressionSyntax || (pNode is InvocationExpressionSyntax && (this.semanticModel.GetTypeInfo(pNode).Type?.Kind == SymbolKind.ErrorType || this.semanticModel.GetSymbolInfo(expression).Symbol == null))))
+                if (pNode is InvocationExpressionSyntax syntax)
                 {
-                    pNode = pNode.Parent;
-
-                    if (pNode is InvocationExpressionSyntax syntax)
-                    {
-                        expression = syntax.Expression;
-                    }
+                    expression = syntax.Expression;
                 }
             }
-
-            return expression;
         }
 
-        public override void VisitReturnStatement(ReturnStatementSyntax node)
-        {
-            var returnDescription = new ReturnDescription(node.Expression?.ToString() ?? string.Empty);
-            this.statements.Add(returnDescription);
+        return expression;
+    }
 
-            base.VisitReturnStatement(node);
-        }
+    public override void VisitReturnStatement(ReturnStatementSyntax node)
+    {
+        var returnDescription = new ReturnDescription(node.Expression?.ToString() ?? string.Empty);
+        this.statements.Add(returnDescription);
 
-        public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
-        {
-            var returnDescription = new ReturnDescription(node.Expression.ToString());
-            this.statements.Add(returnDescription);
+        base.VisitReturnStatement(node);
+    }
 
-            base.VisitArrowExpressionClause(node);
-        }
+    public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+    {
+        var returnDescription = new ReturnDescription(node.Expression.ToString());
+        this.statements.Add(returnDescription);
 
-        public override void VisitAssignmentExpression(AssignmentExpressionSyntax node)
-        {
-            var assignmentDescription = new AssignmentDescription(node.Left.ToString(), node.OperatorToken.Text, node.Right.ToString());
-            this.statements.Add(assignmentDescription);
+        base.VisitArrowExpressionClause(node);
+    }
 
-            base.VisitAssignmentExpression(node);
-        }
+    public override void VisitAssignmentExpression(AssignmentExpressionSyntax node)
+    {
+        var assignmentDescription = new AssignmentDescription(node.Left.ToString(), node.OperatorToken.Text, node.Right.ToString());
+        this.statements.Add(assignmentDescription);
+
+        base.VisitAssignmentExpression(node);
     }
 }

--- a/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
@@ -99,11 +99,13 @@ namespace LivingDocumentation
             var invocation = new InvocationDescription(containingType, methodName);
             this.statements.Add(invocation);
 
-            foreach (var argument in node.ArgumentList.Arguments)
-            {
-                var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), argument.Expression.ToString());
-                invocation.Arguments.Add(argumentDescription);
-            }
+        foreach (var argument in node.ArgumentList.Arguments)
+        {
+                var value = argument.Expression.ResolveValue(this.semanticModel);
+
+                var argumentDescription = new ArgumentDescription(this.semanticModel.GetTypeDisplayString(argument.Expression), value);
+            invocation.Arguments.Add(argumentDescription);
+        }
 
             base.VisitInvocationExpression(node);
         }

--- a/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 internal class InvocationsAnalyzer : CSharpSyntaxWalker

--- a/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/InvocationsAnalyzer.cs
@@ -131,7 +131,7 @@ internal class InvocationsAnalyzer : CSharpSyntaxWalker
 
     public override void VisitReturnStatement(ReturnStatementSyntax node)
     {
-        var returnDescription = new ReturnDescription(node.Expression?.ToString() ?? string.Empty);
+        var returnDescription = new ReturnDescription(node.Expression?.ResolveValue(this.semanticModel) ?? string.Empty);
         this.statements.Add(returnDescription);
 
         base.VisitReturnStatement(node);
@@ -139,7 +139,7 @@ internal class InvocationsAnalyzer : CSharpSyntaxWalker
 
     public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
     {
-        var returnDescription = new ReturnDescription(node.Expression.ToString());
+        var returnDescription = new ReturnDescription(node.Expression.ResolveValue(this.semanticModel));
         this.statements.Add(returnDescription);
 
         base.VisitArrowExpressionClause(node);

--- a/src/LivingDocumentation.Analyzer/Analyzers/LoopingAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/LoopingAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 internal class LoopingAnalyzer : CSharpSyntaxWalker

--- a/src/LivingDocumentation.Analyzer/Analyzers/LoopingAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/LoopingAnalyzer.cs
@@ -2,28 +2,27 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+internal class LoopingAnalyzer : CSharpSyntaxWalker
 {
-    internal class LoopingAnalyzer : CSharpSyntaxWalker
+    private readonly SemanticModel semanticModel;
+    private readonly List<Statement> statements;
+
+    public LoopingAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
     {
-        private readonly SemanticModel semanticModel;
-        private readonly List<Statement> statements;
+        this.semanticModel = semanticModel;
+        this.statements = statements;
+    }
 
-        public LoopingAnalyzer(in SemanticModel semanticModel, List<Statement> statements)
-        {
-            this.semanticModel = semanticModel;
-            this.statements = statements;
-        }
+    public override void VisitForEachStatement(ForEachStatementSyntax node)
+    {
+        var forEachStatement = new ForEach();
+        this.statements.Add(forEachStatement);
 
-        public override void VisitForEachStatement(ForEachStatementSyntax node)
-        {
-            var forEachStatement = new ForEach();
-            this.statements.Add(forEachStatement);
+        forEachStatement.Expression = $"{node.Identifier} in {node.Expression}";
 
-            forEachStatement.Expression = $"{node.Identifier} in {node.Expression}";
-
-            var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, forEachStatement.Statements);
-            invocationAnalyzer.Visit(node.Statement);
-        }
+        var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, forEachStatement.Statements);
+        invocationAnalyzer.Visit(node.Statement);
     }
 }

--- a/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 public class SourceAnalyzer : CSharpSyntaxWalker
@@ -117,6 +113,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         foreach (var variable in node.Declaration.Variables)
         {
             var fieldDescription = new FieldDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
@@ -135,6 +133,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         foreach (var variable in node.Declaration.Variables)
         {
             var eventDescription = new EventDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
@@ -153,6 +153,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         var propertyDescription = new PropertyDescription(this.semanticModel.GetTypeDisplayString(node.Type), node.Identifier.ToString());
         this.currentType.AddMember(propertyDescription);
 
@@ -168,6 +170,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         var enumMemberDescription = new EnumMemberDescription(node.Identifier.ToString(), node.EqualsValue?.Value.ToString());
         this.currentType.AddMember(enumMemberDescription);
 
@@ -179,6 +183,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         var constructorDescription = new ConstructorDescription(node.Identifier.ToString());
         this.currentType.AddMember(constructorDescription);
 
@@ -189,6 +195,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         var methodDescription = new MethodDescription(this.semanticModel.GetTypeInfo(node.ReturnType).Type?.ToDisplayString(), node.Identifier.ToString());
         this.currentType.AddMember(methodDescription);
 
@@ -225,6 +233,8 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
     private void EnsureTypeDefaultAccessModifier(BaseTypeDeclarationSyntax node)
     {
+        if (this.currentType is null) return;
+
         if (!node.Ancestors().Any(a => a.IsKind(SyntaxKind.ClassDeclaration) || a.IsKind(SyntaxKind.StructDeclaration)))
         {
             // Not nested, default is internal
@@ -281,7 +291,7 @@ public class SourceAnalyzer : CSharpSyntaxWalker
             {
                 foreach (var argument in attribute.ArgumentList.Arguments)
                 {
-                    var value = argument.Expression.ResolveValue(this.semanticModel);
+                    var value = argument.Expression!.ResolveValue(this.semanticModel);
 
                     var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression?.ToString(), this.semanticModel.GetTypeDisplayString(argument.Expression), value);
                     attributeDescription.Arguments.Add(argumentDescription);
@@ -305,7 +315,7 @@ public class SourceAnalyzer : CSharpSyntaxWalker
 
         foreach (var parameter in node.ParameterList.Parameters)
         {
-            var parameterDescription = new ParameterDescription(this.semanticModel.GetTypeDisplayString(parameter.Type), parameter.Identifier.ToString());
+            var parameterDescription = new ParameterDescription(this.semanticModel.GetTypeDisplayString(parameter.Type!), parameter.Identifier.ToString());
             method.Parameters.Add(parameterDescription);
 
             parameterDescription.HasDefaultValue = parameter.Default != null;

--- a/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
@@ -78,12 +78,12 @@ namespace LivingDocumentation
                 this.currentType.AddMember(fieldDescription);
 
                 fieldDescription.Modifiers |= ParseModifiers(node.Modifiers);
-                this.EnsureMemberDefaultAccessModifier(fieldDescription);
-                this.ExtractAttributes(node.AttributeLists, fieldDescription.Attributes);
+            this.EnsureMemberDefaultAccessModifier(fieldDescription);
+            this.ExtractAttributes(node.AttributeLists, fieldDescription.Attributes);
 
-                fieldDescription.Initializer = variable.Initializer?.Value.ToString();
-                fieldDescription.DocumentationComments = this.ExtractDocumentation(variable);
-            }
+                fieldDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
+            fieldDescription.DocumentationComments = this.ExtractDocumentation(variable);
+        }
 
             base.VisitFieldDeclaration(node);
         }
@@ -96,12 +96,12 @@ namespace LivingDocumentation
                 this.currentType.AddMember(eventDescription);
 
                 eventDescription.Modifiers |= ParseModifiers(node.Modifiers);
-                this.EnsureMemberDefaultAccessModifier(eventDescription);
-                this.ExtractAttributes(node.AttributeLists, eventDescription.Attributes);
+            this.EnsureMemberDefaultAccessModifier(eventDescription);
+            this.ExtractAttributes(node.AttributeLists, eventDescription.Attributes);
 
-                eventDescription.Initializer = variable.Initializer?.Value.ToString();
-                eventDescription.DocumentationComments = this.ExtractDocumentation(variable);
-            }
+                eventDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
+            eventDescription.DocumentationComments = this.ExtractDocumentation(variable);
+        }
 
             base.VisitEventFieldDeclaration(node);
         }
@@ -112,13 +112,13 @@ namespace LivingDocumentation
             this.currentType.AddMember(propertyDescription);
 
             propertyDescription.Modifiers |= ParseModifiers(node.Modifiers);
-            this.EnsureMemberDefaultAccessModifier(propertyDescription);
-            this.ExtractAttributes(node.AttributeLists, propertyDescription.Attributes);
+        this.EnsureMemberDefaultAccessModifier(propertyDescription);
+        this.ExtractAttributes(node.AttributeLists, propertyDescription.Attributes);
 
-            propertyDescription.Initializer = node.Initializer?.Value.ToString();
-            propertyDescription.DocumentationComments = this.ExtractDocumentation(node);
+            propertyDescription.Initializer = node.Initializer?.Value.ResolveValue(this.semanticModel);
+        propertyDescription.DocumentationComments = this.ExtractDocumentation(node);
 
-            base.VisitPropertyDeclaration(node);
+        base.VisitPropertyDeclaration(node);
         }
 
         public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
@@ -233,17 +233,13 @@ namespace LivingDocumentation
                 attributeDescriptions.Add(attributeDescription);
 
                 if (attribute.ArgumentList != null)
+            {
+                foreach (var argument in attribute.ArgumentList.Arguments)
                 {
-                    foreach (var argument in attribute.ArgumentList.Arguments)
-                    {
-                        var value = argument.Expression switch
-                        {
-                            LiteralExpressionSyntax literalExpression => literalExpression.Token.ValueText,
-                            _ => argument.Expression?.ToString(),
-                        };
+                        var value = argument.Expression.ResolveValue(this.semanticModel);
 
-                        var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression?.ToString(), this.semanticModel.GetTypeDisplayString(argument.Expression), value);
-                        attributeDescription.Arguments.Add(argumentDescription);
+                    var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression?.ToString(), this.semanticModel.GetTypeDisplayString(argument.Expression), value);
+                    attributeDescription.Arguments.Add(argumentDescription);
                     }
                 }
             }

--- a/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
@@ -7,269 +7,314 @@ namespace LivingDocumentation;
 public class SourceAnalyzer : CSharpSyntaxWalker
 {
     private readonly SemanticModel semanticModel;
-        private readonly List<TypeDescription> types;
+    private readonly List<TypeDescription> types;
 
-        private TypeDescription? currentType = null;
+    private TypeDescription? currentType = null;
 
-        public SourceAnalyzer(in SemanticModel semanticModel, List<TypeDescription> types)
-        {
-            this.types = types;
-            this.semanticModel = semanticModel;
-        }
+    public SourceAnalyzer(in SemanticModel semanticModel, List<TypeDescription> types)
+    {
+        this.types = types;
+        this.semanticModel = semanticModel;
+    }
 
-        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
-        {
-            if (this.ProcessedEmbeddedType(node)) return;
+    public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+    {
+        if (this.ProcessedEmbeddedType(node)) return;
 
-            this.ExtractBaseTypeDeclaration(TypeType.Class, node);
+        this.ExtractBaseTypeDeclaration(TypeType.Class, node);
 
-            base.VisitClassDeclaration(node);
-        }
+        base.VisitClassDeclaration(node);
+    }
 
 #if NET6_0_OR_GREATER
-        public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
-        {
-            if (this.ProcessedEmbeddedType(node)) return;
+    public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
+    {
+        if (this.ProcessedEmbeddedType(node)) return;
 
-            var type = TypeType.Class;
-            if (node.ClassOrStructKeyword.ValueText == "struct")
+        var type = TypeType.Class;
+        if (node.ClassOrStructKeyword.ValueText == "struct")
+        {
+            type = TypeType.Struct;
+        }
+
+        this.ExtractBaseTypeDeclaration(type, node);
+
+        base.VisitRecordDeclaration(node);
+
+        // Check for parts that are generated and not declared by the author
+        var symbol = this.semanticModel.GetDeclaredSymbol(node);
+        if (symbol != null)
+        {
+            foreach (var constructor in symbol.Constructors)
             {
-                type = TypeType.Struct;
+                var constructorDescription = new ConstructorDescription(symbol.Name);
+
+                foreach (var parameter in constructor.Parameters)
+                {
+                    var parameterDescription = new ParameterDescription(parameter.Type.ToDisplayString(), parameter.Name);
+                    constructorDescription.Parameters.Add(parameterDescription);
+
+                    parameterDescription.HasDefaultValue = parameter.HasExplicitDefaultValue;
+                }
+
+                if (!this.currentType.Constructors.Any(c => c.Parameters.Select(p => p.Type).SequenceEqual(constructorDescription.Parameters.Select(p => p.Type))))
+                {
+                    this.currentType.AddMember(constructorDescription);
+
+                    constructorDescription.Modifiers |= constructor.IsSealed ? Modifier.Sealed : 0;
+
+                    this.EnsureMemberDefaultAccessModifier(constructorDescription);
+                }
             }
 
-            this.ExtractBaseTypeDeclaration(type, node);
+            foreach (var member in symbol.GetMembers())
+            {
+                if (member is IPropertySymbol property)
+                {
+                    if (this.currentType.Properties.Any(p => p.Name == property.Name))
+                    {
+                        continue;
+                    }
 
-            base.VisitRecordDeclaration(node);
+                    var propertyDescription = new PropertyDescription(property.Type.ToDisplayString(), property.Name);
+                    this.currentType.AddMember(propertyDescription);
+
+                    propertyDescription.Modifiers |= property.IsReadOnly ? Modifier.Readonly : 0;
+
+                    this.EnsureMemberDefaultAccessModifier(propertyDescription);
+                }
+            }
         }
+    }
 #endif
 
-        public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+    public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+    {
+        if (this.ProcessedEmbeddedType(node)) return;
+
+        this.ExtractBaseTypeDeclaration(TypeType.Enum, node);
+
+        base.VisitEnumDeclaration(node);
+    }
+
+    public override void VisitStructDeclaration(StructDeclarationSyntax node)
+    {
+        if (this.ProcessedEmbeddedType(node)) return;
+
+        this.ExtractBaseTypeDeclaration(TypeType.Struct, node);
+
+        base.VisitStructDeclaration(node);
+    }
+
+    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+    {
+        if (this.ProcessedEmbeddedType(node)) return;
+
+        this.ExtractBaseTypeDeclaration(TypeType.Interface, node);
+
+        base.VisitInterfaceDeclaration(node);
+    }
+
+    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        foreach (var variable in node.Declaration.Variables)
         {
-            if (this.ProcessedEmbeddedType(node)) return;
+            var fieldDescription = new FieldDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
+            this.currentType.AddMember(fieldDescription);
 
-            this.ExtractBaseTypeDeclaration(TypeType.Enum, node);
-
-            base.VisitEnumDeclaration(node);
-        }
-
-        public override void VisitStructDeclaration(StructDeclarationSyntax node)
-        {
-            if (this.ProcessedEmbeddedType(node)) return;
-
-            this.ExtractBaseTypeDeclaration(TypeType.Struct, node);
-
-            base.VisitStructDeclaration(node);
-        }
-
-        public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
-        {
-            if (this.ProcessedEmbeddedType(node)) return;
-
-            this.ExtractBaseTypeDeclaration(TypeType.Interface, node);
-
-            base.VisitInterfaceDeclaration(node);
-        }
-
-        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
-        {
-            foreach (var variable in node.Declaration.Variables)
-            {
-                var fieldDescription = new FieldDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
-                this.currentType.AddMember(fieldDescription);
-
-                fieldDescription.Modifiers |= ParseModifiers(node.Modifiers);
+            fieldDescription.Modifiers |= ParseModifiers(node.Modifiers);
             this.EnsureMemberDefaultAccessModifier(fieldDescription);
             this.ExtractAttributes(node.AttributeLists, fieldDescription.Attributes);
 
-                fieldDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
+            fieldDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
             fieldDescription.DocumentationComments = this.ExtractDocumentation(variable);
         }
 
-            base.VisitFieldDeclaration(node);
-        }
+        base.VisitFieldDeclaration(node);
+    }
 
-        public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+    public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+    {
+        foreach (var variable in node.Declaration.Variables)
         {
-            foreach (var variable in node.Declaration.Variables)
-            {
-                var eventDescription = new EventDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
-                this.currentType.AddMember(eventDescription);
+            var eventDescription = new EventDescription(this.semanticModel.GetTypeDisplayString(node.Declaration.Type), variable.Identifier.ValueText);
+            this.currentType.AddMember(eventDescription);
 
-                eventDescription.Modifiers |= ParseModifiers(node.Modifiers);
+            eventDescription.Modifiers |= ParseModifiers(node.Modifiers);
             this.EnsureMemberDefaultAccessModifier(eventDescription);
             this.ExtractAttributes(node.AttributeLists, eventDescription.Attributes);
 
-                eventDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
+            eventDescription.Initializer = variable.Initializer?.Value.ResolveValue(this.semanticModel);
             eventDescription.DocumentationComments = this.ExtractDocumentation(variable);
         }
 
-            base.VisitEventFieldDeclaration(node);
-        }
+        base.VisitEventFieldDeclaration(node);
+    }
 
-        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
-        {
-            var propertyDescription = new PropertyDescription(this.semanticModel.GetTypeDisplayString(node.Type), node.Identifier.ToString());
-            this.currentType.AddMember(propertyDescription);
+    public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    {
+        var propertyDescription = new PropertyDescription(this.semanticModel.GetTypeDisplayString(node.Type), node.Identifier.ToString());
+        this.currentType.AddMember(propertyDescription);
 
-            propertyDescription.Modifiers |= ParseModifiers(node.Modifiers);
+        propertyDescription.Modifiers |= ParseModifiers(node.Modifiers);
         this.EnsureMemberDefaultAccessModifier(propertyDescription);
         this.ExtractAttributes(node.AttributeLists, propertyDescription.Attributes);
 
-            propertyDescription.Initializer = node.Initializer?.Value.ResolveValue(this.semanticModel);
+        propertyDescription.Initializer = node.Initializer?.Value.ResolveValue(this.semanticModel);
         propertyDescription.DocumentationComments = this.ExtractDocumentation(node);
 
         base.VisitPropertyDeclaration(node);
+    }
+
+    public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
+    {
+        var enumMemberDescription = new EnumMemberDescription(node.Identifier.ToString(), node.EqualsValue?.Value.ToString());
+        this.currentType.AddMember(enumMemberDescription);
+
+        enumMemberDescription.Modifiers |= Modifier.Public;
+        enumMemberDescription.DocumentationComments = this.ExtractDocumentation(node);
+
+        base.VisitEnumMemberDeclaration(node);
+    }
+
+    public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+    {
+        var constructorDescription = new ConstructorDescription(node.Identifier.ToString());
+        this.currentType.AddMember(constructorDescription);
+
+        this.ExtractBaseMethodDeclaration(node, constructorDescription);
+
+        base.VisitConstructorDeclaration(node);
+    }
+
+    public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        var methodDescription = new MethodDescription(this.semanticModel.GetTypeInfo(node.ReturnType).Type?.ToDisplayString(), node.Identifier.ToString());
+        this.currentType.AddMember(methodDescription);
+
+        this.ExtractBaseMethodDeclaration(node, methodDescription);
+
+        base.VisitMethodDeclaration(node);
+    }
+
+    private void ExtractBaseTypeDeclaration(TypeType type, BaseTypeDeclarationSyntax node)
+    {
+        var currentType = new TypeDescription(type, this.semanticModel.GetDeclaredSymbol(node)?.ToDisplayString());
+        if (!this.types.Contains(currentType))
+        {
+            this.types.Add(currentType);
+            this.currentType = currentType;
+        }
+        else
+        {
+            this.currentType = this.types.First(t => string.Equals(t.FullName, currentType.FullName, StringComparison.Ordinal));
         }
 
-        public override void VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
+        if (node.BaseList != null)
         {
-            var enumMemberDescription = new EnumMemberDescription(node.Identifier.ToString(), node.EqualsValue?.Value.ToString());
-            this.currentType.AddMember(enumMemberDescription);
-
-            enumMemberDescription.Modifiers |= Modifier.Public;
-            enumMemberDescription.DocumentationComments = this.ExtractDocumentation(node);
-
-            base.VisitEnumMemberDeclaration(node);
+            this.currentType.BaseTypes.AddRange(node.BaseList.Types.Select(t => this.semanticModel.GetTypeDisplayString(t.Type)));
         }
 
-        public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        this.currentType.Modifiers |= ParseModifiers(node.Modifiers);
+        this.EnsureTypeDefaultAccessModifier(node);
+
+        this.currentType.DocumentationComments = this.ExtractDocumentation(node);
+
+        this.ExtractAttributes(node.AttributeLists, this.currentType.Attributes);
+    }
+
+    private void EnsureTypeDefaultAccessModifier(BaseTypeDeclarationSyntax node)
+    {
+        if (!node.Ancestors().Any(a => a.IsKind(SyntaxKind.ClassDeclaration) || a.IsKind(SyntaxKind.StructDeclaration)))
         {
-            var constructorDescription = new ConstructorDescription(node.Identifier.ToString());
-            this.currentType.AddMember(constructorDescription);
-
-            this.ExtractBaseMethodDeclaration(node, constructorDescription);
-
-            base.VisitConstructorDeclaration(node);
-        }
-
-        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
-        {
-            var methodDescription = new MethodDescription(this.semanticModel.GetTypeInfo(node.ReturnType).Type?.ToDisplayString(), node.Identifier.ToString());
-            this.currentType.AddMember(methodDescription);
-
-            this.ExtractBaseMethodDeclaration(node, methodDescription);
-
-            base.VisitMethodDeclaration(node);
-        }
-
-        private void ExtractBaseTypeDeclaration(TypeType type, BaseTypeDeclarationSyntax node)
-        {
-            var currentType = new TypeDescription(type, this.semanticModel.GetDeclaredSymbol(node)?.ToDisplayString());
-            if (!this.types.Contains(currentType))
+            // Not nested, default is internal
+            if (!this.currentType.IsPublic() && !this.currentType.IsInternal())
             {
-                this.types.Add(currentType);
-                this.currentType = currentType;
-            }
-            else
-            {
-                this.currentType = this.types.First(t => string.Equals(t.FullName, currentType.FullName, StringComparison.Ordinal));
-            }
-
-            if (node.BaseList != null)
-            {
-                this.currentType.BaseTypes.AddRange(node.BaseList.Types.Select(t => this.semanticModel.GetTypeDisplayString(t.Type)));
-            }
-
-            this.currentType.Modifiers |= ParseModifiers(node.Modifiers);
-            this.EnsureTypeDefaultAccessModifier(node);
-
-            this.currentType.DocumentationComments = this.ExtractDocumentation(node);
-
-            this.ExtractAttributes(node.AttributeLists, this.currentType.Attributes);
-        }
-
-        private void EnsureTypeDefaultAccessModifier(BaseTypeDeclarationSyntax node)
-        {
-            if (!node.Ancestors().Any(a => a.IsKind(SyntaxKind.ClassDeclaration) || a.IsKind(SyntaxKind.StructDeclaration)))
-            {
-                // Not nested, default is internal
-                if (!this.currentType.IsPublic() && !this.currentType.IsInternal())
-                {
-                    this.currentType.Modifiers |= Modifier.Internal;
-                }
-            }
-            else
-            {
-                // Nested, default is private
-                if (!this.currentType.IsPublic() && !this.currentType.IsInternal() && !this.currentType.IsPrivate() && !this.currentType.IsProtected())
-                {
-                    this.currentType.Modifiers |= Modifier.Private;
-                }
+                this.currentType.Modifiers |= Modifier.Internal;
             }
         }
-
-        private void EnsureMemberDefaultAccessModifier(IHaveModifiers member)
+        else
         {
-            // Default is private
-            if (!member.IsPublic() && !member.IsInternal() && !member.IsPrivate() && !member.IsProtected())
+            // Nested, default is private
+            if (!this.currentType.IsPublic() && !this.currentType.IsInternal() && !this.currentType.IsPrivate() && !this.currentType.IsProtected())
             {
-                member.Modifiers |= Modifier.Private;
+                this.currentType.Modifiers |= Modifier.Private;
             }
         }
+    }
 
-        private bool ProcessedEmbeddedType(SyntaxNode node)
+    private void EnsureMemberDefaultAccessModifier(IHaveModifiers member)
+    {
+        // Default is private
+        if (!member.IsPublic() && !member.IsInternal() && !member.IsPrivate() && !member.IsProtected())
         {
-            if (this.currentType == null || (!node.Parent.IsKind(SyntaxKind.ClassDeclaration) && !node.Parent.IsKind(SyntaxKind.StructDeclaration)))
-            {
-                return false;
-            }
+            member.Modifiers |= Modifier.Private;
+        }
+    }
 
-            var embeddedAnalyzer = new SourceAnalyzer(this.semanticModel, this.types);
-            embeddedAnalyzer.Visit(node);
-
-            return true;
+    private bool ProcessedEmbeddedType(SyntaxNode node)
+    {
+        if (this.currentType == null || (!node.Parent.IsKind(SyntaxKind.ClassDeclaration) && !node.Parent.IsKind(SyntaxKind.StructDeclaration)))
+        {
+            return false;
         }
 
-        private void ExtractAttributes(SyntaxList<AttributeListSyntax> attributes, List<IAttributeDescription> attributeDescriptions)
+        var embeddedAnalyzer = new SourceAnalyzer(this.semanticModel, this.types);
+        embeddedAnalyzer.Visit(node);
+
+        return true;
+    }
+
+    private void ExtractAttributes(SyntaxList<AttributeListSyntax> attributes, List<IAttributeDescription> attributeDescriptions)
+    {
+        if (attributes == null)
         {
-            if (attributes == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            foreach (var attribute in attributes.SelectMany(a => a.Attributes))
-            {
-                var attributeDescription = new AttributeDescription(this.semanticModel.GetTypeDisplayString(attribute), attribute.Name.ToString());
-                attributeDescriptions.Add(attributeDescription);
+        foreach (var attribute in attributes.SelectMany(a => a.Attributes))
+        {
+            var attributeDescription = new AttributeDescription(this.semanticModel.GetTypeDisplayString(attribute), attribute.Name.ToString());
+            attributeDescriptions.Add(attributeDescription);
 
-                if (attribute.ArgumentList != null)
+            if (attribute.ArgumentList != null)
             {
                 foreach (var argument in attribute.ArgumentList.Arguments)
                 {
-                        var value = argument.Expression.ResolveValue(this.semanticModel);
+                    var value = argument.Expression.ResolveValue(this.semanticModel);
 
                     var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression?.ToString(), this.semanticModel.GetTypeDisplayString(argument.Expression), value);
                     attributeDescription.Arguments.Add(argumentDescription);
-                    }
                 }
             }
         }
+    }
 
-        private DocumentationCommentsDescription? ExtractDocumentation(SyntaxNode node)
+    private DocumentationCommentsDescription? ExtractDocumentation(SyntaxNode node)
+    {
+        return DocumentationCommentsDescription.Parse(this.semanticModel.GetDeclaredSymbol(node)?.GetDocumentationCommentXml());
+    }
+
+    private void ExtractBaseMethodDeclaration(BaseMethodDeclarationSyntax node, IHaveAMethodBody method)
+    {
+        method.Modifiers |= ParseModifiers(node.Modifiers);
+        method.DocumentationComments = this.ExtractDocumentation(node);
+
+        this.EnsureMemberDefaultAccessModifier(method);
+        this.ExtractAttributes(node.AttributeLists, method.Attributes);
+
+        foreach (var parameter in node.ParameterList.Parameters)
         {
-            return DocumentationCommentsDescription.Parse(this.semanticModel.GetDeclaredSymbol(node)?.GetDocumentationCommentXml());
+            var parameterDescription = new ParameterDescription(this.semanticModel.GetTypeDisplayString(parameter.Type), parameter.Identifier.ToString());
+            method.Parameters.Add(parameterDescription);
+
+            parameterDescription.HasDefaultValue = parameter.Default != null;
+            this.ExtractAttributes(parameter.AttributeLists, parameterDescription.Attributes);
         }
 
-        private void ExtractBaseMethodDeclaration(BaseMethodDeclarationSyntax node, IHaveAMethodBody method)
-        {
-            method.Modifiers |= ParseModifiers(node.Modifiers);
-            method.DocumentationComments = this.ExtractDocumentation(node);
-
-            this.EnsureMemberDefaultAccessModifier(method);
-            this.ExtractAttributes(node.AttributeLists, method.Attributes);
-
-            foreach (var parameter in node.ParameterList.Parameters)
-            {
-                var parameterDescription = new ParameterDescription(this.semanticModel.GetTypeDisplayString(parameter.Type), parameter.Identifier.ToString());
-                method.Parameters.Add(parameterDescription);
-
-                parameterDescription.HasDefaultValue = parameter.Default != null;
-                this.ExtractAttributes(parameter.AttributeLists, parameterDescription.Attributes);
-            }
-
-            var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, method.Statements);
-            invocationAnalyzer.Visit((SyntaxNode?)node.Body ?? node.ExpressionBody);
-        }
+        var invocationAnalyzer = new InvocationsAnalyzer(this.semanticModel, method.Statements);
+        invocationAnalyzer.Visit((SyntaxNode?)node.Body ?? node.ExpressionBody);
+    }
 
     private static Modifier ParseModifiers(SyntaxTokenList modifiers)
     {

--- a/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
@@ -2,11 +2,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+public class SourceAnalyzer : CSharpSyntaxWalker
 {
-    public class SourceAnalyzer : CSharpSyntaxWalker
-    {
-        private readonly SemanticModel semanticModel;
+    private readonly SemanticModel semanticModel;
         private readonly List<TypeDescription> types;
 
         private TypeDescription? currentType = null;
@@ -271,9 +271,8 @@ namespace LivingDocumentation
             invocationAnalyzer.Visit((SyntaxNode?)node.Body ?? node.ExpressionBody);
         }
 
-        private static Modifier ParseModifiers(SyntaxTokenList modifiers)
-        {
-            return (Modifier)modifiers.Select(m => Enum.TryParse(typeof(Modifier), m.ValueText, true, out var value) ? (int)value : 0).Sum();
-        }
+    private static Modifier ParseModifiers(SyntaxTokenList modifiers)
+    {
+        return (Modifier)modifiers.Select(m => Enum.TryParse(typeof(Modifier), m.ValueText, true, out var value) ? (int)value : 0).Sum();
     }
 }

--- a/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
+++ b/src/LivingDocumentation.Analyzer/Analyzers/SourceAnalyzer.cs
@@ -293,7 +293,7 @@ public class SourceAnalyzer : CSharpSyntaxWalker
                 {
                     var value = argument.Expression!.ResolveValue(this.semanticModel);
 
-                    var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression?.ToString(), this.semanticModel.GetTypeDisplayString(argument.Expression), value);
+                    var argumentDescription = new AttributeArgumentDescription(argument.NameEquals?.Name.ToString() ?? argument.Expression.ResolveValue(this.semanticModel), this.semanticModel.GetTypeDisplayString(argument.Expression!), value);
                     attributeDescription.Arguments.Add(argumentDescription);
                 }
             }

--- a/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
@@ -8,8 +8,90 @@ public static class ExpressionSyntaxExtensions
         {
             IdentifierNameSyntax identifier when semanticModel.GetSymbolInfo(identifier).Symbol is IFieldSymbol field && field.IsConst => field.ConstantValue!.ToString()!,
             IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            InterpolatedStringExpressionSyntax interpolatedString => interpolatedString.Contents.ToString(),
             LiteralExpressionSyntax literal => literal.Token.ValueText,
+            BinaryExpressionSyntax binary when binary.Right is InterpolatedStringExpressionSyntax || binary.Right is LiteralExpressionSyntax => ConcatBinaryExpression(binary),
+            ArrayCreationExpressionSyntax arrayCreation => FormatArrayCreation(arrayCreation),
+            ObjectCreationExpressionSyntax objectCreation => FormatObjectCreation(objectCreation),
             _ => expression.ToString()
         };
+    }
+
+    /// <summary>
+    /// Format Object initializers to a single line, removing newlines and indenting.
+    /// </summary>
+    private static string FormatObjectCreation(ObjectCreationExpressionSyntax objectCreation)
+    {
+        var initializer = objectCreation.Initializer;
+        if (initializer is not null)
+        {
+            var expressions = new SeparatedSyntaxList<SyntaxNode>();
+
+            foreach (var expression in initializer.Expressions)
+            {
+                expressions = expressions.Add(expression.WithoutTrivia().WithLeadingTrivia(SyntaxFactory.Space));
+            }
+
+            initializer = initializer.Update(initializer.OpenBraceToken.WithoutTrivia(), expressions, initializer.CloseBraceToken.WithLeadingTrivia(SyntaxFactory.Space));
+        }
+
+        return objectCreation.Update(objectCreation.NewKeyword, objectCreation.Type.WithTrailingTrivia(SyntaxFactory.Space), objectCreation.ArgumentList, initializer).ToString();
+    }
+
+    /// <summary>
+    /// Format Array initializers to a single line, removing newlines and indenting.
+    /// </summary>
+    private static string FormatArrayCreation(ArrayCreationExpressionSyntax arrayCreation)
+    {
+        var initializer = arrayCreation.Initializer;
+        if (initializer is not null)
+        {
+            var expressions = new SeparatedSyntaxList<SyntaxNode>();
+
+            foreach (var expression in initializer.Expressions)
+            {
+                expressions = expressions.Add(expression.WithLeadingTrivia(SyntaxFactory.Space));
+            }
+
+            initializer = initializer.Update(initializer.OpenBraceToken.WithoutTrivia(), expressions, initializer.CloseBraceToken);
+        }
+
+        return arrayCreation.Update(arrayCreation.NewKeyword, arrayCreation.Type, initializer).ToString();
+    }
+
+    /// <summary>
+    /// Format String concatination to a single string, removing newlines and indenting.
+    /// </summary>
+    private static string ConcatBinaryExpression(BinaryExpressionSyntax binary)
+    {
+        var parts = new Stack<string>();
+
+        AddPart(binary.Right);
+
+        var left = binary.Left;
+
+        while (left is BinaryExpressionSyntax binaryExpression && binaryExpression.IsKind(SyntaxKind.AddExpression))
+        {
+            AddPart(binaryExpression.Right);
+
+            left = binaryExpression.Left;
+        }
+
+        AddPart(left);
+
+        return string.Join(string.Empty, parts);
+
+        void AddPart(ExpressionSyntax binary)
+        {
+            switch (binary)
+            {
+                case InterpolatedStringExpressionSyntax interpolatedRight:
+                    parts.Push(interpolatedRight.Contents.ToFullString());
+                    break;
+                case LiteralExpressionSyntax literalRight:
+                    parts.Push(literalRight.Token.ValueText);
+                    break;
+            }
+        }
     }
 }

--- a/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
@@ -1,6 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 public static class ExpressionSyntaxExtensions

--- a/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/LivingDocumentation.Analyzer/Extensions/ExpressionSyntaxExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LivingDocumentation;
+
+public static class ExpressionSyntaxExtensions
+{
+    public static string ResolveValue(this ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax identifier when semanticModel.GetSymbolInfo(identifier).Symbol is IFieldSymbol field && field.IsConst => field.ConstantValue!.ToString()!,
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            LiteralExpressionSyntax literal => literal.Token.ValueText,
+            _ => expression.ToString()
+        };
+    }
+}

--- a/src/LivingDocumentation.Analyzer/Extensions/SemanticModelExtensions.cs
+++ b/src/LivingDocumentation.Analyzer/Extensions/SemanticModelExtensions.cs
@@ -1,25 +1,24 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+public static class SemanticModelExtensions
 {
-    public static class SemanticModelExtensions
+    public static string GetTypeDisplayString(this SemanticModel semanticModel, SyntaxNode node)
     {
-        public static string GetTypeDisplayString(this SemanticModel semanticModel, SyntaxNode node)
+        return semanticModel.GetTypeInfo(node).Type.ToDisplayString();
+    }
+
+    public static string GetTypeDisplayString(this SemanticModel semanticModel, ExpressionSyntax expression)
+    {
+        var type = semanticModel.GetTypeInfo(expression).Type?.ToDisplayString();
+        if (type != null)
         {
-            return semanticModel.GetTypeInfo(node).Type.ToDisplayString();
+            return type;
         }
 
-        public static string GetTypeDisplayString(this SemanticModel semanticModel, ExpressionSyntax expression)
-        {
-            var type = semanticModel.GetTypeInfo(expression).Type?.ToDisplayString();
-            if (type != null)
-            {
-                return type;
-            }
-
-            return semanticModel.GetTypeInfo(expression).ConvertedType?.ToDisplayString();
-        }
+        return semanticModel.GetTypeInfo(expression).ConvertedType?.ToDisplayString();
     }
 }

--- a/src/LivingDocumentation.Analyzer/Extensions/SemanticModelExtensions.cs
+++ b/src/LivingDocumentation.Analyzer/Extensions/SemanticModelExtensions.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace LivingDocumentation;
 
 public static class SemanticModelExtensions

--- a/src/LivingDocumentation.Analyzer/LivingDocumentation.Analyzer.csproj
+++ b/src/LivingDocumentation.Analyzer/LivingDocumentation.Analyzer.csproj
@@ -34,6 +34,9 @@
 
   <ItemGroup>
     <Using Include="CommandLine" />
+    <Using Include="Microsoft.CodeAnalysis" />
+    <Using Include="Microsoft.CodeAnalysis.CSharp" />
+    <Using Include="Microsoft.CodeAnalysis.CSharp.Syntax" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/LivingDocumentation.Analyzer/Options.cs
+++ b/src/LivingDocumentation.Analyzer/Options.cs
@@ -1,44 +1,25 @@
-namespace LivingDocumentation
+namespace LivingDocumentation;
+ 
+public partial class Program
 {
-    public partial class Program
+    public class Options
     {
-        public class Options
-        {
-            [Option("solution", Required = true, SetName = "solution", HelpText = "The solution to analyze.")]
-            public string? SolutionPath
-            {
-                get; set;
-            }
+        [Option("solution", Required = true, SetName = "solution", HelpText = "The solution to analyze.")]
+        public string? SolutionPath { get; set; }
 
-            [Option("project", Required = true, SetName = "project", HelpText = "The project to analyze.")]
-            public string? ProjectPath
-            {
-                get; set;
-            }
+        [Option("project", Required = true, SetName = "project", HelpText = "The project to analyze.")]
+        public string? ProjectPath { get; set; }
 
-            [Option("output", Required = true, HelpText = "The location of the output.")]
-            public string? OutputPath
-            {
-                get; set;
-            }
+        [Option("output", Required = true, HelpText = "The location of the output.")]
+        public string? OutputPath { get; set; }
 
-            [Option('v', "verbose", Default = false, HelpText = "Show warnings during compilation.")]
-            public bool VerboseOutput
-            {
-                get; set;
-            }
+        [Option('v', "verbose", Default = false, HelpText = "Show warnings during compilation.")]
+        public bool VerboseOutput { get; set; }
 
-            [Option('p', "pretty", Default = false, HelpText = "Store JSON output in indented formatting.")]
-            public bool PrettyPrint
-            {
-                get; set;
-            }
+        [Option('p', "pretty", Default = false, HelpText = "Store JSON output in indented formatting.")]
+        public bool PrettyPrint { get; set; }
 
-            [Option('q', "quiet", Default = false, HelpText = "Don't output informational messages.")]
-            public bool Quiet
-            {
-                get; set;
-            }
-        }
+        [Option('q', "quiet", Default = false, HelpText = "Don't output informational messages.")]
+        public bool Quiet { get; set; }
     }
 }

--- a/src/LivingDocumentation.Analyzer/Program.cs
+++ b/src/LivingDocumentation.Analyzer/Program.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using Buildalyzer;
 using Buildalyzer.Workspaces;
-using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace LivingDocumentation;

--- a/src/LivingDocumentation.Analyzer/Program.cs
+++ b/src/LivingDocumentation.Analyzer/Program.cs
@@ -4,114 +4,113 @@ using Buildalyzer.Workspaces;
 using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 
-namespace LivingDocumentation
+namespace LivingDocumentation;
+
+public static partial class Program
 {
-    public static partial class Program
+    private static ParserResult<Options>? ParsedResults;
+
+    public static Options RuntimeOptions { get; private set; } = new Options();
+
+    public static async Task Main(string[] args)
     {
-        private static ParserResult<Options>? ParsedResults;
+        ParsedResults = Parser.Default.ParseArguments<Options>(args);
 
-        public static Options RuntimeOptions { get; private set; } = new Options();
+        await ParsedResults.MapResult(
+            options => RunApplicationAsync(options),
+            errors => Task.FromResult(1)
+        ).ConfigureAwait(false);
+    }
 
-        public static async Task Main(string[] args)
+    private static async Task RunApplicationAsync(Options options)
+    {
+        RuntimeOptions = options;
+
+        var types = new List<TypeDescription>();
+
+        var stopwatch = Stopwatch.StartNew();
+        if (options.SolutionPath is not null)
         {
-            ParsedResults = Parser.Default.ParseArguments<Options>(args);
-
-            await ParsedResults.MapResult(
-                options => RunApplicationAsync(options),
-                errors => Task.FromResult(1)
-            ).ConfigureAwait(false);
+            await AnalyzeSolutionFileAsync(types, options.SolutionPath).ConfigureAwait(false);
+        } else
+        {
+            await AnalyzeProjectFileAsync(types, options.ProjectPath!).ConfigureAwait(false);
         }
+        stopwatch.Stop();
 
-        private static async Task RunApplicationAsync(Options options)
+        // Write analysis 
+        var serializerSettings = JsonDefaults.SerializerSettings();
+        serializerSettings.Formatting = options.PrettyPrint ? Formatting.Indented : Formatting.None;
+
+        var result = JsonConvert.SerializeObject(types.OrderBy(t => t.FullName), serializerSettings);
+
+        await File.WriteAllTextAsync(options.OutputPath!, result).ConfigureAwait(false);
+
+        if (!options.Quiet)
         {
-            RuntimeOptions = options;
-
-            var types = new List<TypeDescription>();
-
-            var stopwatch = Stopwatch.StartNew();
-            if (options.SolutionPath is not null)
-            {
-                await AnalyzeSolutionFileAsync(types, options.SolutionPath).ConfigureAwait(false);
-            } else
-            {
-                await AnalyzeProjectFileAsync(types, options.ProjectPath!).ConfigureAwait(false);
-            }
-            stopwatch.Stop();
-
-            // Write analysis 
-            var serializerSettings = JsonDefaults.SerializerSettings();
-            serializerSettings.Formatting = options.PrettyPrint ? Formatting.Indented : Formatting.None;
-
-            var result = JsonConvert.SerializeObject(types.OrderBy(t => t.FullName), serializerSettings);
-
-            await File.WriteAllTextAsync(options.OutputPath!, result).ConfigureAwait(false);
-
-            if (!options.Quiet)
-            {
-                Console.WriteLine($"Living Documentation Analysis output generated in {stopwatch.ElapsedMilliseconds}ms at {options.OutputPath}");
-            }
+            Console.WriteLine($"Living Documentation Analysis output generated in {stopwatch.ElapsedMilliseconds}ms at {options.OutputPath}");
         }
+    }
 
-        private static async Task AnalyzeSolutionFileAsync(List<TypeDescription> types, string solutionFile)
+    private static async Task AnalyzeSolutionFileAsync(List<TypeDescription> types, string solutionFile)
+    {
+        var manager = new AnalyzerManager(solutionFile);
+        var workspace = manager.GetWorkspace();
+        var assembliesInSolution = workspace.CurrentSolution.Projects.Select(p => p.AssemblyName).ToList();
+
+        // Every project in the solution, except unit test projects
+        var projects = workspace.CurrentSolution.Projects
+            .Where(p => !manager.Projects.First(mp => p.Id.Id == mp.Value.ProjectGuid).Value.ProjectFile.PackageReferences.Any(pr => pr.Name.Contains("Test", StringComparison.Ordinal)));
+
+        foreach (var project in projects)
         {
-            var manager = new AnalyzerManager(solutionFile);
-            var workspace = manager.GetWorkspace();
-            var assembliesInSolution = workspace.CurrentSolution.Projects.Select(p => p.AssemblyName).ToList();
-
-            // Every project in the solution, except unit test projects
-            var projects = workspace.CurrentSolution.Projects
-                .Where(p => !manager.Projects.First(mp => p.Id.Id == mp.Value.ProjectGuid).Value.ProjectFile.PackageReferences.Any(pr => pr.Name.Contains("Test", StringComparison.Ordinal)));
-
-            foreach (var project in projects)
-            {
-                await AnalyzeProjectAsyc(types, project).ConfigureAwait(false);
-            }
-
-            workspace.Dispose();
-        }
-
-        private static async Task AnalyzeProjectFileAsync(List<TypeDescription> types, string projectFile)
-        {
-            var manager = new AnalyzerManager();
-            manager.GetProject(projectFile);
-            var workspace = manager.GetWorkspace();
-
-            var project = workspace.CurrentSolution.Projects.First();
-
             await AnalyzeProjectAsyc(types, project).ConfigureAwait(false);
-
-            workspace.Dispose();
         }
 
-        private static async Task AnalyzeProjectAsyc(List<TypeDescription> types, Project project)
-        {
-            var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
-            if (compilation is null)
-            {
-                return;
-            }
+        workspace.Dispose();
+    }
 
-            if (RuntimeOptions.VerboseOutput)
+    private static async Task AnalyzeProjectFileAsync(List<TypeDescription> types, string projectFile)
+    {
+        var manager = new AnalyzerManager();
+        manager.GetProject(projectFile);
+        var workspace = manager.GetWorkspace();
+
+        var project = workspace.CurrentSolution.Projects.First();
+
+        await AnalyzeProjectAsyc(types, project).ConfigureAwait(false);
+
+        workspace.Dispose();
+    }
+
+    private static async Task AnalyzeProjectAsyc(List<TypeDescription> types, Project project)
+    {
+        var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
+        if (compilation is null)
+        {
+            return;
+        }
+
+        if (RuntimeOptions.VerboseOutput)
+        {
+            var diagnostics = compilation.GetDiagnostics();
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
             {
-                var diagnostics = compilation.GetDiagnostics();
-                if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                Console.WriteLine($"The following errors occured during compilation of project '{project.FilePath}'");
+                foreach (var diagnostic in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error))
                 {
-                    Console.WriteLine($"The following errors occured during compilation of project '{project.FilePath}'");
-                    foreach (var diagnostic in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error))
-                    {
-                        Console.WriteLine("- " + diagnostic.ToString());
-                    }
+                    Console.WriteLine("- " + diagnostic.ToString());
                 }
             }
+        }
 
-            // Every file in the project
-            foreach (var syntaxTree in compilation.SyntaxTrees)
-            {
-                var semanticModel = compilation.GetSemanticModel(syntaxTree, true);
+        // Every file in the project
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree, true);
 
-                var visitor = new SourceAnalyzer(semanticModel, types);
-                visitor.Visit(syntaxTree.GetRoot());
-            }
+            var visitor = new SourceAnalyzer(semanticModel, types);
+            visitor.Visit(syntaxTree.GetRoot());
         }
     }
 }

--- a/src/LivingDocumentation.Descriptions/ArgumentDescription.cs
+++ b/src/LivingDocumentation.Descriptions/ArgumentDescription.cs
@@ -7,9 +7,9 @@ public class ArgumentDescription
 
     public string Text { get; }
 
-    public ArgumentDescription(string type, string text)
+    public ArgumentDescription(string? type, string? text)
     {
-        this.Type = type;
-        this.Text = text;
+        this.Type = type ?? throw new ArgumentNullException(nameof(type));
+        this.Text = text ?? throw new ArgumentNullException(nameof(text));
     }
 }

--- a/src/LivingDocumentation.Descriptions/AttributeArgumentDescription.cs
+++ b/src/LivingDocumentation.Descriptions/AttributeArgumentDescription.cs
@@ -9,10 +9,10 @@ public class AttributeArgumentDescription : IAttributeArgumentDescription
 
     public string Value { get; }
 
-    public AttributeArgumentDescription(string name, string type, string value)
+    public AttributeArgumentDescription(string? name, string? type, string? value)
     {
-        this.Name = name;
-        this.Type = type;
-        this.Value = value;
+        this.Name = name ?? throw new ArgumentNullException("name");
+        this.Type = type ?? throw new ArgumentNullException("type");
+        this.Value = value ?? throw new ArgumentNullException("value");
     }
 }

--- a/src/LivingDocumentation.Descriptions/AttributeDescription.cs
+++ b/src/LivingDocumentation.Descriptions/AttributeDescription.cs
@@ -11,9 +11,9 @@ public class AttributeDescription : IAttributeDescription
     [JsonConverter(typeof(ConcreteTypeConverter<List<AttributeArgumentDescription>>))]
     public List<IAttributeArgumentDescription> Arguments { get; } = new();
 
-    public AttributeDescription(string type, string name)
+    public AttributeDescription(string? type, string? name)
     {
-        this.Type = type;
-        this.Name = name;
+        this.Type = type ?? throw new ArgumentNullException(nameof(type));
+        this.Name = name ?? throw new ArgumentNullException(nameof(name));
     }
 }

--- a/src/LivingDocumentation.Descriptions/EnumMemberDescription.cs
+++ b/src/LivingDocumentation.Descriptions/EnumMemberDescription.cs
@@ -3,11 +3,11 @@ namespace LivingDocumentation;
 [DebuggerDisplay("EnumMember {Name,nq}")]
 public class EnumMemberDescription : MemberDescription
 {
-    public string Value { get; }
+    public string? Value { get; }
 
     public override MemberType MemberType => MemberType.EnumMember;
 
-    public EnumMemberDescription(string name, string value)
+    public EnumMemberDescription(string name, string? value)
         : base(name)
     {
         this.Value = value;

--- a/src/LivingDocumentation.Descriptions/InvocationDescription.cs
+++ b/src/LivingDocumentation.Descriptions/InvocationDescription.cs
@@ -9,9 +9,9 @@ public class InvocationDescription : Statement
 
     public List<ArgumentDescription> Arguments { get; } = new();
 
-    public InvocationDescription(string containingType, string name)
+    public InvocationDescription(string? containingType, string? name)
     {
-        this.ContainingType = containingType;
-        this.Name = name;
+        this.ContainingType = containingType ?? throw new ArgumentNullException(nameof(containingType));
+        this.Name = name ?? throw new ArgumentNullException(nameof(name));
     }
 }

--- a/src/LivingDocumentation.Descriptions/MemberDescription.cs
+++ b/src/LivingDocumentation.Descriptions/MemberDescription.cs
@@ -22,7 +22,7 @@ public abstract class MemberDescription : IMemberable
 
     public MemberDescription(string name)
     {
-        this.Name = name;
+        this.Name = name ?? throw new ArgumentNullException("name");
     }
 
     public override bool Equals(object obj)

--- a/src/LivingDocumentation.Descriptions/MethodDescription.cs
+++ b/src/LivingDocumentation.Descriptions/MethodDescription.cs
@@ -14,10 +14,10 @@ public class MethodDescription : MemberDescription, IHaveAMethodBody
 
     public override MemberType MemberType => MemberType.Method;
         
-    public MethodDescription(string returnType, string name)
+    public MethodDescription(string? returnType, string name)
         : base(name)
     {
-        this.ReturnType = returnType;
+        this.ReturnType = returnType ?? "void";
     }
 
     [OnDeserialized]

--- a/src/LivingDocumentation.Descriptions/TypeDescription.cs
+++ b/src/LivingDocumentation.Descriptions/TypeDescription.cs
@@ -21,7 +21,7 @@ public class TypeDescription : IHaveModifiers
     [JsonProperty(Order = 6, PropertyName = nameof(Events))]
     private readonly List<EventDescription> events = new();
 
-    public TypeDescription(TypeType type, string fullName)
+    public TypeDescription(TypeType type, string? fullName)
     {
         this.Type = type;
         this.FullName = fullName ?? string.Empty;

--- a/tests/LivingDocumentation.Analyzer.Tests/AttributeTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/AttributeTests.cs
@@ -1,394 +1,390 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class AttributeTests
 {
-    [TestClass]
-    public class AttributeTests
+    [TestMethod]
+    public void ClassWithoutAttributes_Should_HaveEmptyAttributeCollection()
     {
-        [TestMethod]
-        public void ClassWithoutAttributes_Should_HaveEmptyAttributeCollection()
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().BeEmpty();
         }
+        ";
 
-        [TestMethod]
-        public void ClassWithAttribute_Should_HaveAttributeInCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ClassWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        [System.Obsolete]
+        class Test
         {
-            // Assign
-            var source = @"
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().HaveCount(1);
+        types[0].Attributes[0].Should().NotBeNull();
+        types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void EnumWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        enum Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void EnumWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        [System.Obsolete]
+        enum Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().HaveCount(1);
+        types[0].Attributes[0].Should().NotBeNull();
+        types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void InterfaceWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        interface Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void InterfaceWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        [System.Obsolete]
+        interface Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().HaveCount(1);
+        types[0].Attributes[0].Should().NotBeNull();
+        types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void StructWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        struct Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void StructWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        [System.Obsolete]
+        struct Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Attributes.Should().HaveCount(1);
+        types[0].Attributes[0].Should().NotBeNull();
+        types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void MethodWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void MethodWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
             [System.Obsolete]
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().HaveCount(1);
-            types[0].Attributes[0].Should().NotBeNull();
-            types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+            void Method() {}
         }
+        ";
 
-        [TestMethod]
-        public void EnumWithoutAttributes_Should_HaveEmptyAttributeCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Attributes.Should().HaveCount(1);
+        types[0].Methods[0].Attributes[0].Should().NotBeNull();
+        types[0].Methods[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void ParameterWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            enum Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().BeEmpty();
+            void Method(string body) {}
         }
+        ";
 
-        [TestMethod]
-        public void EnumWithAttribute_Should_HaveAttributeInCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Parameters[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ParameterWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
+            void Method([System.ParamArray] string[] parameters) {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, ignoreErrorCodes: "CS0674");
+
+        // Assert
+        types[0].Methods[0].Parameters[0].Attributes.Should().HaveCount(1);
+        types[0].Methods[0].Parameters[0].Attributes[0].Should().NotBeNull();
+        types[0].Methods[0].Parameters[0].Attributes[0].Name.Should().Be("System.ParamArray");
+    }
+
+    [TestMethod]
+    public void ConstructorWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            Test() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Constructors[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ConstructorWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
             [System.Obsolete]
-            enum Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().HaveCount(1);
-            types[0].Attributes[0].Should().NotBeNull();
-            types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+            Test() {}
         }
+        ";
 
-        [TestMethod]
-        public void InterfaceWithoutAttributes_Should_HaveEmptyAttributeCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Constructors[0].Attributes.Should().HaveCount(1);
+        types[0].Constructors[0].Attributes[0].Should().NotBeNull();
+        types[0].Constructors[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void FieldWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        public class Test
         {
-            // Assign
-            var source = @"
-            interface Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().BeEmpty();
+            public int field;
         }
+        ";
 
-        [TestMethod]
-        public void InterfaceWithAttribute_Should_HaveAttributeInCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void FieldWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        public class Test
         {
-            // Assign
-            var source = @"
             [System.Obsolete]
-            interface Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().HaveCount(1);
-            types[0].Attributes[0].Should().NotBeNull();
-            types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+            public int field;
         }
+        ";
 
-        [TestMethod]
-        public void StructWithoutAttributes_Should_HaveEmptyAttributeCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields[0].Attributes.Should().HaveCount(1);
+        types[0].Fields[0].Attributes[0].Should().NotBeNull();
+        types[0].Fields[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void EventWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            struct Test
-            {
-            }
-            ";
+            event System.Action @event;
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().BeEmpty();
+            Test() { @event(); }
         }
+        ";
 
-        [TestMethod]
-        public void StructWithAttribute_Should_HaveAttributeInCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Events[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void EventWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
             [System.Obsolete]
-            struct Test
-            {
-            }
-            ";
+            event System.Action @event;
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Attributes.Should().HaveCount(1);
-            types[0].Attributes[0].Should().NotBeNull();
-            types[0].Attributes[0].Name.Should().Be("System.Obsolete");
+            Test() { @event(); }
         }
+        ";
 
-        [TestMethod]
-        public void MethodWithoutAttributes_Should_HaveEmptyAttributeCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Events[0].Attributes.Should().HaveCount(1);
+        types[0].Events[0].Attributes[0].Should().NotBeNull();
+        types[0].Events[0].Attributes[0].Name.Should().Be("System.Obsolete");
+    }
+
+    [TestMethod]
+    public void PropertyWithoutAttributes_Should_HaveEmptyAttributeCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Attributes.Should().BeEmpty();
+            int Property { get; set; }
         }
+        ";
 
-        [TestMethod]
-        public void MethodWithAttribute_Should_HaveAttributeInCollection()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Properties[0].Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void PropertyWithAttribute_Should_HaveAttributeInCollection()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                [System.Obsolete]
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Attributes.Should().HaveCount(1);
-            types[0].Methods[0].Attributes[0].Should().NotBeNull();
-            types[0].Methods[0].Attributes[0].Name.Should().Be("System.Obsolete");
+            [System.Obsolete]
+            int Property { get; set; }
         }
+        ";
 
-        [TestMethod]
-        public void ParameterWithoutAttributes_Should_HaveEmptyAttributeCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                void Method(string body) {}
-            }
-            ";
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Parameters[0].Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParameterWithAttribute_Should_HaveAttributeInCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                void Method([System.ParamArray] string[] parameters) {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source, ignoreErrorCodes: "CS0674");
-
-            // Assert
-            types[0].Methods[0].Parameters[0].Attributes.Should().HaveCount(1);
-            types[0].Methods[0].Parameters[0].Attributes[0].Should().NotBeNull();
-            types[0].Methods[0].Parameters[0].Attributes[0].Name.Should().Be("System.ParamArray");
-        }
-
-        [TestMethod]
-        public void ConstructorWithoutAttributes_Should_HaveEmptyAttributeCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                Test() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Constructors[0].Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ConstructorWithAttribute_Should_HaveAttributeInCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                [System.Obsolete]
-                Test() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Constructors[0].Attributes.Should().HaveCount(1);
-            types[0].Constructors[0].Attributes[0].Should().NotBeNull();
-            types[0].Constructors[0].Attributes[0].Name.Should().Be("System.Obsolete");
-        }
-
-        [TestMethod]
-        public void FieldWithoutAttributes_Should_HaveEmptyAttributeCollection()
-        {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                public int field;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Fields[0].Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void FieldWithAttribute_Should_HaveAttributeInCollection()
-        {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                [System.Obsolete]
-                public int field;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Fields[0].Attributes.Should().HaveCount(1);
-            types[0].Fields[0].Attributes[0].Should().NotBeNull();
-            types[0].Fields[0].Attributes[0].Name.Should().Be("System.Obsolete");
-        }
-
-        [TestMethod]
-        public void EventWithoutAttributes_Should_HaveEmptyAttributeCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                event System.Action @event;
-
-                Test() { @event(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Events[0].Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void EventWithAttribute_Should_HaveAttributeInCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                [System.Obsolete]
-                event System.Action @event;
-
-                Test() { @event(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Events[0].Attributes.Should().HaveCount(1);
-            types[0].Events[0].Attributes[0].Should().NotBeNull();
-            types[0].Events[0].Attributes[0].Name.Should().Be("System.Obsolete");
-        }
-
-        [TestMethod]
-        public void PropertyWithoutAttributes_Should_HaveEmptyAttributeCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                int Property { get; set; }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Properties[0].Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void PropertyWithAttribute_Should_HaveAttributeInCollection()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                [System.Obsolete]
-                int Property { get; set; }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Properties[0].Attributes.Should().HaveCount(1);
-            types[0].Properties[0].Attributes[0].Should().NotBeNull();
-            types[0].Properties[0].Attributes[0].Name.Should().Be("System.Obsolete");
-        }
+        // Assert
+        types[0].Properties[0].Attributes.Should().HaveCount(1);
+        types[0].Properties[0].Attributes[0].Should().NotBeNull();
+        types[0].Properties[0].Attributes[0].Name.Should().Be("System.Obsolete");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/ClassModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/ClassModifierTests.cs
@@ -1,100 +1,96 @@
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class ClassModifierTests
 {
-    [TestClass]
-    public class ClassModifierTests
+    [TestMethod]
+    public void ClassWithoutModifier_Should_HaveDefaultInternalModifier()
     {
-        [TestMethod]
-        public void ClassWithoutModifier_Should_HaveDefaultInternalModifier()
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Internal);
+    }
+
+    [TestMethod]
+    public void PublicClass_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Public);
+    }
+
+    [TestMethod]
+    public void StaticClass_Should_HaveStaticModifier()
+    {
+        // Assign
+        var source = @"
+        static class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().HaveFlag(Modifier.Static);
+    }
+
+    [TestMethod]
+    public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            class NestedTest
             {
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Internal);
         }
+        ";
 
-        [TestMethod]
-        public void PublicClass_Should_HavePublicModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[1].Modifiers.Should().Be(Modifier.Private);
+    }
+
+    [TestMethod]
+    public void NestedPublicClass_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            public class Test
+            public class NestedTest
             {
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Public);
         }
+        ";
 
-        [TestMethod]
-        public void StaticClass_Should_HaveStaticModifier()
-        {
-            // Assign
-            var source = @"
-            static class Test
-            {
-            }
-            ";
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().HaveFlag(Modifier.Static);
-        }
-
-        [TestMethod]
-        public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                class NestedTest
-                {
-                }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[1].Modifiers.Should().Be(Modifier.Private);
-        }
-
-        [TestMethod]
-        public void NestedPublicClass_Should_HavePublicModifier()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                public class NestedTest
-                {
-                }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[1].Modifiers.Should().Be(Modifier.Public);
-        }
+        // Assert
+        types[1].Modifiers.Should().Be(Modifier.Public);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/ClassModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/ClassModifierTests.cs
@@ -3,94 +3,86 @@ namespace LivingDocumentation.Analyzer.Tests;
 [TestClass]
 public class ClassModifierTests
 {
+    [DataRow("class Test {}", Modifier.Internal, DisplayName = "A type description about a class without a modifier should contain the `internal` modifier")]
+    [DataRow("public class Test {}", Modifier.Public, DisplayName = "A type description about a `public` class should contain the `public` modifier")]
+    [DataRow("internal class Test {}", Modifier.Internal, DisplayName = "A type description about an `internal` class should contain the `internal` modifier")]
     [TestMethod]
-    public void ClassWithoutModifier_Should_HaveDefaultInternalModifier()
+    public void ClassesShouldHaveTheCorrectAccessModifiers(string @class, Modifier modifier)
     {
         // Assign
-        var source = @"
+        var source = @class;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(modifier);
+    }
+
+    [TestMethod]
+    [DataRow("public abstract class Test {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` class should contain the `abstract` modifier")]
+    [DataRow("static class Test {}", Modifier.Static, DisplayName = "A type description about a `static` class should contain the `static` modifier")]
+    [DataRow("unsafe class Test {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` class should contain the `unsafe` modifier")]
+    public void ClassesShouldHaveTheCorrectModifiers(string @class, Modifier modifier)
+    {
+        // Assign
+        var source = @class;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067", "CS0626", "CS1998");
+
+        // Assert
+        types[0].Modifiers.Should().HaveFlag(modifier);
+    }
+
+    [DataRow("class NestedTest {}", Modifier.Private, DisplayName = "A type description about a nested class without a modifier should contain the `private` modifier")]
+    [DataRow("private class NestedTest {}", Modifier.Private, DisplayName = "A type description about a `private` nested class should contain the `private` modifier")]
+    [DataRow("public class NestedTest {}", Modifier.Public, DisplayName = "A type description about a `public` nested class should contain the `public` modifier")]
+    [DataRow("protected class NestedTest {}", Modifier.Protected, DisplayName = "A type description about a `protected` nested class should contain the `protected` modifier")]
+    [DataRow("internal class NestedTest {}", Modifier.Internal, DisplayName = "A type description about an `internal` nested class should contain the `internal` modifier")]
+    [DataRow("protected internal class NestedTest {}", Modifier.Protected | Modifier.Internal, DisplayName = "A type description about a `protected internal` nested class should contain the `protected` and `internal` modifiers")]
+    [DataRow("private protected class NestedTest {}", Modifier.Private | Modifier.Protected, DisplayName = "A type description about a `private protected` nested class should contain the `private` and `protected` modifiers")]
+    [TestMethod]
+    public void NestedClassesShouldHaveTheCorrectAccessModifiers(string @class, Modifier modifier)
+    {
+        // Assign
+        var source = @$"
         class Test
-        {
-        }
+        {{
+            {@class}
+        }}
         ";
 
         // Act
-        var types = TestHelper.VisitSyntaxTree(source);
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
 
         // Assert
-        types[0].Modifiers.Should().Be(Modifier.Internal);
+        types[1].Modifiers.Should().Be(modifier);
     }
 
     [TestMethod]
-    public void PublicClass_Should_HavePublicModifier()
+    [DataRow("public abstract class NestedTest {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` nested class should contain the `abstract` modifier")]
+    [DataRow("new class NestedB {}", Modifier.New, DisplayName = "A type description about a `new` nested class should contain the `new` modifier")]
+    [DataRow("partial class NestedTest {}", Modifier.Partial, DisplayName = "A type description about a `partial` nested class should contain the `partial` modifier")]
+    [DataRow("static class NestedTest {}", Modifier.Static, DisplayName = "A type description about a `static` nested class should contain the `static` modifier")]
+    [DataRow("unsafe class NestedTest {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` nested class should contain the `unsafe` modifier")]
+    public void NestedClassesShouldHaveTheCorrectModifiers(string @class, Modifier modifier)
     {
         // Assign
-        var source = @"
-        public class Test
-        {
-        }
+        var source = @$"
+        class Test : ClassB
+        {{
+            {@class}
+        }}
+        class ClassB {{
+            internal class NestedB {{}};
+        }}
         ";
 
         // Act
-        var types = TestHelper.VisitSyntaxTree(source);
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
 
         // Assert
-        types[0].Modifiers.Should().Be(Modifier.Public);
-    }
-
-    [TestMethod]
-    public void StaticClass_Should_HaveStaticModifier()
-    {
-        // Assign
-        var source = @"
-        static class Test
-        {
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[0].Modifiers.Should().HaveFlag(Modifier.Static);
-    }
-
-    [TestMethod]
-    public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
-    {
-        // Assign
-        var source = @"
-        class Test
-        {
-            class NestedTest
-            {
-            }
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[1].Modifiers.Should().Be(Modifier.Private);
-    }
-
-    [TestMethod]
-    public void NestedPublicClass_Should_HavePublicModifier()
-    {
-        // Assign
-        var source = @"
-        class Test
-        {
-            public class NestedTest
-            {
-            }
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[1].Modifiers.Should().Be(Modifier.Public);
+        types[1].Modifiers.Should().HaveFlag(modifier);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ArgumentDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ArgumentDescriptionTests.cs
@@ -1,25 +1,21 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class ArgumentDescriptionTests
 {
-    [TestClass]
-    public class ArgumentDescriptionTests
+    [TestMethod]
+    public void ArgumentDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void ArgumentDescription_Constructor_Should_SetType()
-        {
-            var description = new ArgumentDescription("System.String", null);
+        var description = new ArgumentDescription("System.String", "");
 
-            description.Type.Should().Be("System.String");
-        }
+        description.Type.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void ArgumentDescription_Constructor_Should_SetName()
-        {
-            var description = new ArgumentDescription(null, "TestText");
+    [TestMethod]
+    public void ArgumentDescription_Constructor_Should_SetName()
+    {
+        var description = new ArgumentDescription("", "TestText");
 
-            description.Text.Should().Be("TestText");
-        }
+        description.Text.Should().Be("TestText");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/AttributeArgumentDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/AttributeArgumentDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class AttributeArgumentDescriptionTests
 {
-    [TestClass]
-    public class AttributeArgumentDescriptionTests
+    [TestMethod]
+    public void AttributeArgumentDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void AttributeArgumentDescription_Constructor_Should_SetType()
-        {
-            var description = new AttributeArgumentDescription(null, "System.String", null);
+        var description = new AttributeArgumentDescription("", "System.String", "");
 
-            description.Type.Should().Be("System.String");
-        }
+        description.Type.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void AttributeArgumentDescription_Constructor_Should_SetName()
-        {
-            var description = new AttributeArgumentDescription("TestArgument", null, null);
+    [TestMethod]
+    public void AttributeArgumentDescription_Constructor_Should_SetName()
+    {
+        var description = new AttributeArgumentDescription("TestArgument", "", "");
 
-            description.Name.Should().Be("TestArgument");
-        }
+        description.Name.Should().Be("TestArgument");
+    }
 
-        [TestMethod]
-        public void AttributeArgumentDescription_Constructor_Should_SetValue()
-        {
-            var description = new AttributeArgumentDescription(null, null, "TestValue");
+    [TestMethod]
+    public void AttributeArgumentDescription_Constructor_Should_SetValue()
+    {
+        var description = new AttributeArgumentDescription("", "", "TestValue");
 
-            description.Value.Should().Be("TestValue");
-        }
+        description.Value.Should().Be("TestValue");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/AttributeDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/AttributeDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class AttributeDescriptionTests
 {
-    [TestClass]
-    public class AttributeDescriptionTests
+    [TestMethod]
+    public void AttributeDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void AttributeDescription_Constructor_Should_SetType()
-        {
-            var description = new AttributeDescription("System.String", null);
+        var description = new AttributeDescription("System.String", "");
 
-            description.Type.Should().Be("System.String");
-        }
+        description.Type.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void AttributeDescription_Constructor_Should_SetName()
-        {
-            var description = new AttributeDescription(null, "TestParameter");
+    [TestMethod]
+    public void AttributeDescription_Constructor_Should_SetName()
+    {
+        var description = new AttributeDescription("", "TestParameter");
 
-            description.Name.Should().Be("TestParameter");
-        }
+        description.Name.Should().Be("TestParameter");
+    }
 
-        [TestMethod]
-        public void AttributeDescription_Arguments_Should_BeEmpty()
-        {
-            var description = new AttributeDescription(null, null);
+    [TestMethod]
+    public void AttributeDescription_Arguments_Should_BeEmpty()
+    {
+        var description = new AttributeDescription("", "");
 
-            description.Arguments.Should().BeEmpty();
-        }
+        description.Arguments.Should().BeEmpty();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ConstructureDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ConstructureDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class ConstructorDescriptionTests
 {
-    [TestClass]
-    public class ConstructorDescriptionTests
+    [TestMethod]
+    public void ConstructorDescription_Constructor_Should_SetName()
     {
-        [TestMethod]
-        public void ConstructorDescription_Constructor_Should_SetName()
-        {
-            var description = new ConstructorDescription("TestConstructor");
+        var description = new ConstructorDescription("TestConstructor");
 
-            description.Name.Should().Be("TestConstructor");
-        }
+        description.Name.Should().Be("TestConstructor");
+    }
 
-        [TestMethod]
-        public void ConstructorDescription_MemberType_Should_BeConstructor()
-        {
-            var description = new ConstructorDescription(null);
+    [TestMethod]
+    public void ConstructorDescription_MemberType_Should_BeConstructor()
+    {
+        var description = new ConstructorDescription("");
 
-            description.MemberType.Should().Be(MemberType.Constructor);
-        }
+        description.MemberType.Should().Be(MemberType.Constructor);
+    }
 
-        [TestMethod]
-        public void ConstructorDescription_Parameters_Should_BeEmpty()
-        {
-            var description = new ConstructorDescription(null);
+    [TestMethod]
+    public void ConstructorDescription_Parameters_Should_BeEmpty()
+    {
+        var description = new ConstructorDescription("");
 
-            description.Parameters.Should().BeEmpty();
-        }
+        description.Parameters.Should().BeEmpty();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/EnumMemberDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/EnumMemberDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class EnumMemberDescriptionTests
 {
-    [TestClass]
-    public class EnumMemberDescriptionTests
+    [TestMethod]
+    public void EnumMemberDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void EnumMemberDescription_Constructor_Should_SetType()
-        {
-            var description = new EnumMemberDescription(null, "TestValue");
+        var description = new EnumMemberDescription("", "TestValue");
 
-            description.Value.Should().Be("TestValue");
-        }
+        description.Value.Should().Be("TestValue");
+    }
 
-        [TestMethod]
-        public void EnumMemberDescription_Constructor_Should_SetName()
-        {
-            var description = new EnumMemberDescription("TestEnumMember", null);
+    [TestMethod]
+    public void EnumMemberDescription_Constructor_Should_SetName()
+    {
+        var description = new EnumMemberDescription("TestEnumMember", "");
 
-            description.Name.Should().Be("TestEnumMember");
-        }
+        description.Name.Should().Be("TestEnumMember");
+    }
 
-        [TestMethod]
-        public void EnumMemberDescription_MemberType_Should_BeEnumMember()
-        {
-            var description = new EnumMemberDescription(null, null);
+    [TestMethod]
+    public void EnumMemberDescription_MemberType_Should_BeEnumMember()
+    {
+        var description = new EnumMemberDescription("", "");
 
-            description.MemberType.Should().Be(MemberType.EnumMember);
-        }
+        description.MemberType.Should().Be(MemberType.EnumMember);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/EventDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/EventDescriptionTests.cs
@@ -1,51 +1,48 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class EventDescriptionTests
 {
-    [TestClass]
-    public class EventDescriptionTests
+    [TestMethod]
+    public void EventDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void EventDescription_Constructor_Should_SetType()
+        var description = new EventDescription("System.String", "");
+
+        description.Type.Should().Be("System.String");
+    }
+
+    [TestMethod]
+    public void EventDescription_Constructor_Should_SetName()
+    {
+        var description = new EventDescription("", "TestEvent");
+
+        description.Name.Should().Be("TestEvent");
+    }
+
+    [TestMethod]
+    public void EventDescription_MemberType_Should_BeProperty()
+    {
+        var description = new EventDescription("", "");
+
+        description.MemberType.Should().Be(MemberType.Event);
+    }
+
+    [TestMethod]
+    public void EventDescription_HasInitializer_Should_BeDefaultFalse()
+    {
+        var description = new EventDescription("", "");
+
+        description.HasInitializer.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void EventDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
+    {
+        var description = new EventDescription("", "")
         {
-            var description = new EventDescription("System.String", null);
+            Initializer = "1"
+        };
 
-            description.Type.Should().Be("System.String");
-        }
-
-        [TestMethod]
-        public void EventDescription_Constructor_Should_SetName()
-        {
-            var description = new EventDescription(null, "TestEvent");
-
-            description.Name.Should().Be("TestEvent");
-        }
-
-        [TestMethod]
-        public void EventDescription_MemberType_Should_BeProperty()
-        {
-            var description = new EventDescription(null, null);
-
-            description.MemberType.Should().Be(MemberType.Event);
-        }
-
-        [TestMethod]
-        public void EventDescription_HasInitializer_Should_BeDefaultFalse()
-        {
-            var description = new EventDescription(null, null);
-
-            description.HasInitializer.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void EventDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
-        {
-            var description = new EventDescription(null, null);
-
-            description.Initializer = "1";
-
-            description.HasInitializer.Should().BeTrue();
-        }
+        description.HasInitializer.Should().BeTrue();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/FieldDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/FieldDescriptionTests.cs
@@ -1,52 +1,48 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class FieldDescriptionTests
 {
-    [TestClass]
-    public class FieldDescriptionTests
+    [TestMethod]
+    public void FieldDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void FieldDescription_Constructor_Should_SetType()
+        var description = new FieldDescription("System.String", "");
+
+        description.Type.Should().Be("System.String");
+    }
+
+    [TestMethod]
+    public void FieldDescription_Constructor_Should_SetName()
+    {
+        var description = new FieldDescription("", "TestField");
+
+        description.Name.Should().Be("TestField");
+    }
+
+    [TestMethod]
+    public void FieldDescription_MemberType_Should_BeField()
+    {
+        var description = new FieldDescription("", "");
+
+        description.MemberType.Should().Be(MemberType.Field);
+    }
+
+    [TestMethod]
+    public void FieldDescription_HasInitializer_Should_BeDefaultFalse()
+    {
+        var description = new FieldDescription("", "");
+
+        description.HasInitializer.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void FieldDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
+    {
+        var description = new FieldDescription("", "")
         {
-            var description = new FieldDescription("System.String", null);
+            Initializer = "1"
+        };
 
-            description.Type.Should().Be("System.String");
-        }
-
-        [TestMethod]
-        public void FieldDescription_Constructor_Should_SetName()
-        {
-            var description = new FieldDescription(null, "TestField");
-
-            description.Name.Should().Be("TestField");
-        }
-
-        [TestMethod]
-        public void FieldDescription_MemberType_Should_BeField()
-        {
-            var description = new FieldDescription(null, null);
-
-            description.MemberType.Should().Be(MemberType.Field);
-        }
-
-        [TestMethod]
-        public void FieldDescription_HasInitializer_Should_BeDefaultFalse()
-        {
-            var description = new FieldDescription(null, null);
-
-            description.HasInitializer.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void FieldDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
-        {
-            var description = new FieldDescription(null, null);
-
-            description.Initializer = "1";
-
-            description.HasInitializer.Should().BeTrue();
-        }
+        description.HasInitializer.Should().BeTrue();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/InvocationDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/InvocationDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class InvocationDescriptionTests
 {
-    [TestClass]
-    public class InvocationDescriptionTests
+    [TestMethod]
+    public void InvocationDescription_Constructor_Should_SetName()
     {
-        [TestMethod]
-        public void InvocationDescription_Constructor_Should_SetName()
-        {
-            var description = new InvocationDescription(null, "TestInvocation");
+        var description = new InvocationDescription("", "TestInvocation");
 
-            description.Name.Should().Be("TestInvocation");
-        }
+        description.Name.Should().Be("TestInvocation");
+    }
 
-        [TestMethod]
-        public void InvocationDescription_Constructor_Should_SetContainingType()
-        {
-            var description = new InvocationDescription("System.String", null);
+    [TestMethod]
+    public void InvocationDescription_Constructor_Should_SetContainingType()
+    {
+        var description = new InvocationDescription("System.String", "");
 
-            description.ContainingType.Should().Be("System.String");
-        }
+        description.ContainingType.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void InvocationDescription_Arguments_Should_BeEmpty()
-        {
-            var description = new InvocationDescription(null, null);
+    [TestMethod]
+    public void InvocationDescription_Arguments_Should_BeEmpty()
+    {
+        var description = new InvocationDescription("", "");
 
-            description.Arguments.Should().BeEmpty();
-        }
+        description.Arguments.Should().BeEmpty();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/MethodDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/MethodDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class MethodDescriptionTests
 {
-    [TestClass]
-    public class MethodDescriptionTests
+    [TestMethod]
+    public void MethodDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void MethodDescription_Constructor_Should_SetType()
-        {
-            var description = new MethodDescription("System.String", null);
+        var description = new MethodDescription("System.String", "");
 
-            description.ReturnType.Should().Be("System.String");
-        }
+        description.ReturnType.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void MethodDescription_Constructor_Should_SetName()
-        {
-            var description = new MethodDescription(null, "TestMethod");
+    [TestMethod]
+    public void MethodDescription_Constructor_Should_SetName()
+    {
+        var description = new MethodDescription("", "TestMethod");
 
-            description.Name.Should().Be("TestMethod");
-        }
+        description.Name.Should().Be("TestMethod");
+    }
 
-        [TestMethod]
-        public void MethodDescription_MemberType_Should_BeMethod()
-        {
-            var description = new MethodDescription(null, null);
+    [TestMethod]
+    public void MethodDescription_MemberType_Should_BeMethod()
+    {
+        var description = new MethodDescription("", "");
 
-            description.MemberType.Should().Be(MemberType.Method);
-        }
+        description.MemberType.Should().Be(MemberType.Method);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ParameterDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/ParameterDescriptionTests.cs
@@ -1,33 +1,29 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class ParameterDescriptionTests
 {
-    [TestClass]
-    public class ParameterDescriptionTests
+    [TestMethod]
+    public void ParameterDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void ParameterDescription_Constructor_Should_SetType()
-        {
-            var description = new ParameterDescription("System.String", null);
+        var description = new ParameterDescription("System.String", null);
 
-            description.Type.Should().Be("System.String");
-        }
+        description.Type.Should().Be("System.String");
+    }
 
-        [TestMethod]
-        public void ParameterDescription_Constructor_Should_SetName()
-        {
-            var description = new ParameterDescription(null, "TestParameter");
+    [TestMethod]
+    public void ParameterDescription_Constructor_Should_SetName()
+    {
+        var description = new ParameterDescription(null, "TestParameter");
 
-            description.Name.Should().Be("TestParameter");
-        }
+        description.Name.Should().Be("TestParameter");
+    }
 
-        [TestMethod]
-        public void ParameterDescription_HasDefaultValue_Should_BeDefaultFalse()
-        {
-            var description = new ParameterDescription(null, null);
+    [TestMethod]
+    public void ParameterDescription_HasDefaultValue_Should_BeDefaultFalse()
+    {
+        var description = new ParameterDescription(null, null);
 
-            description.HasDefaultValue.Should().BeFalse();
-        }
+        description.HasDefaultValue.Should().BeFalse();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/PropertyDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/PropertyDescriptionTests.cs
@@ -1,51 +1,48 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class PropertyDescriptionTests
 {
-    [TestClass]
-    public class PropertyDescriptionTests
+    [TestMethod]
+    public void PropertyDescription_Constructor_Should_SetType()
     {
-        [TestMethod]
-        public void PropertyDescription_Constructor_Should_SetType()
+        var description = new PropertyDescription("System.String", "");
+
+        description.Type.Should().Be("System.String");
+    }
+
+    [TestMethod]
+    public void PropertyDescription_Constructor_Should_SetName()
+    {
+        var description = new PropertyDescription("", "TestProperty");
+
+        description.Name.Should().Be("TestProperty");
+    }
+
+    [TestMethod]
+    public void PropertyDescription_MemberType_Should_BeProperty()
+    {
+        var description = new PropertyDescription("", "");
+
+        description.MemberType.Should().Be(MemberType.Property);
+    }
+
+    [TestMethod]
+    public void PropertyDescription_HasInitializer_Should_BeDefaultFalse()
+    {
+        var description = new PropertyDescription("", "");
+
+        description.HasInitializer.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void PropertyDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
+    {
+        var description = new PropertyDescription("", "")
         {
-            var description = new PropertyDescription("System.String", null);
+            Initializer = "1"
+        };
 
-            description.Type.Should().Be("System.String");
-        }
-
-        [TestMethod]
-        public void PropertyDescription_Constructor_Should_SetName()
-        {
-            var description = new PropertyDescription(null, "TestProperty");
-
-            description.Name.Should().Be("TestProperty");
-        }
-
-        [TestMethod]
-        public void PropertyDescription_MemberType_Should_BeProperty()
-        {
-            var description = new PropertyDescription(null, null);
-
-            description.MemberType.Should().Be(MemberType.Property);
-        }
-
-        [TestMethod]
-        public void PropertyDescription_HasInitializer_Should_BeDefaultFalse()
-        {
-            var description = new PropertyDescription(null, null);
-
-            description.HasInitializer.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void PropertyDescription_HasInitializer_Should_BeTrueIfInitializerIsSet()
-        {
-            var description = new PropertyDescription(null, null);
-
-            description.Initializer = "1";
-
-            description.HasInitializer.Should().BeTrue();
-        }
+        description.HasInitializer.Should().BeTrue();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/Descriptions/TypeDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/Descriptions/TypeDescriptionTests.cs
@@ -1,264 +1,259 @@
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class TypeDescriptionTests
 {
-    [TestClass]
-    public class TypeDescriptionTests
+    [TestMethod]
+    public void TypeDescription_GetHashCode_Should_BeTheSame()
     {
-        [TestMethod]
-        public void TypeDescription_GetHashCode_Should_BeTheSame()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass").GetHashCode();
-            var descriptionY = new TypeDescription(0, "TestNamespace.TestClass").GetHashCode();
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass").GetHashCode();
+        var descriptionY = new TypeDescription(0, "TestNamespace.TestClass").GetHashCode();
 
-            descriptionX.Should().Be(descriptionY);
+        descriptionX.Should().Be(descriptionY);
+    }
+
+    [TestMethod]
+    public void TypeDescription_GetHashCode_Should_ShouldBeTheSameForDifferentTypeTypes()
+    {
+        var descriptionX = new TypeDescription(TypeType.Class, "TestNamespace.TestClass").GetHashCode();
+        var descriptionY = new TypeDescription(TypeType.Interface, "TestNamespace.TestClass").GetHashCode();
+
+        descriptionX.Should().Be(descriptionY);
+    }
+
+    [TestMethod]
+    public void TypeDescription_GetHashCode_Should_DifferentNamesShouldDiffer()
+    {
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass1").GetHashCode();
+        var descriptionY = new TypeDescription(0, "TestNamespace.TestClass2").GetHashCode();
+
+        descriptionX.Should().NotBe(descriptionY);
+    }
+
+    [TestMethod]
+    public void TypeDescription_Equals_Should_BeTrueForSameTypeDescriptions()
+    {
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
+        var descriptionY = new TypeDescription(0, "TestNamespace.TestClass");
+
+        descriptionX.Equals(descriptionY).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Equals_Should_BeFalseForDifferentCasing()
+    {
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
+        var descriptionY = new TypeDescription(0, "testnamespace.testclass");
+
+        descriptionX.Equals(descriptionY).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Equals_Should_BeFalseForDifferentTypeDescriptions()
+    {
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass1");
+        var descriptionY = new TypeDescription(0, "TestNamespace.TestClass2");
+
+        descriptionX.Equals(descriptionY).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Equals_Should_BeFalseForDifferentObjects()
+    {
+        var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
+        var descriptionY = new object();
+
+        descriptionX.Equals(descriptionY).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Name_Should_BeFullNameIfThereAreNoDots()
+    {
+        var description = new TypeDescription(0, "TestClass");
+
+        description.Name.Should().Be("TestClass");
+    }
+
+    [TestMethod]
+    public void TypeDescription_Name_Should_BeParsedFromFullName()
+    {
+        var description = new TypeDescription(0, "TestNamespace.TestClass");
+
+        description.Name.Should().Be("TestClass");
+    }
+
+    [TestMethod]
+    public void TypeDescription_Namespace_Should_BeEmptyIfThereAreNoDots()
+    {
+        var description = new TypeDescription(0, "TestClass");
+
+        description.Namespace.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Namespace_Should_BeParsedFromFullName()
+    {
+        var description = new TypeDescription(0, "TestNamespace.TestClass");
+
+        description.Namespace.Should().Be("TestNamespace");
+    }
+
+    [TestMethod]
+    public void TypeDescription_Constructor_Should_SetFullName()
+    {
+        var description = new TypeDescription(0, "TestNamespace.TestClass");
+
+        description.FullName.Should().Be("TestNamespace.TestClass");
+    }
+
+    [TestMethod]
+    public void TypeDescription_Constructor_Should_SetFullNameEmptyIfNull()
+    {
+        var description = new TypeDescription(TypeType.Class, default);
+
+        description.FullName.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Constructor_Should_SetType()
+    {
+        var description = new TypeDescription(TypeType.Struct, default);
+
+        description.Type.Should().Be(TypeType.Struct);
+    }
+
+    [TestMethod]
+    public void TypeDescription_AddMember_Should_ThrowNotSupportedException()
+    {
+        var description = new TypeDescription(default, default);
+
+        Action action = () => { description.AddMember(new UnsupportedMemberDescription("")); };
+
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [TestMethod]
+    public void TypeDescription_BaseTypes_Should_BeEmpty()
+    {
+        var description = new TypeDescription(default, default);
+
+        description.BaseTypes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TypeDescription_Attributes_Should_BeEmpty()
+    {
+        var description = new TypeDescription(default, null);
+
+        description.Attributes.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TypeDescription_MethodBodies_ConstuctorsAndMethodBodies_Should_BeReturnConcatenated()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+        var c = new ConstructorDescription("Test");
+        description.AddMember(c);
+        var m = new MethodDescription("void", "Method");
+        description.AddMember(m);
+
+        // Act
+        var bodies = description.MethodBodies();
+
+        // Assert
+        bodies.Should().AllBeAssignableTo<IHaveAMethodBody>();
+        bodies.Should().BeEquivalentTo(new IHaveAMethodBody[] { c, m });
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsType_DoesNotHaveAnyBaseTypes_Should_ReturnFalse()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+
+        // Act
+        var implementsType = description.ImplementsType("System.Object");
+
+        // Assert
+        implementsType.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsType_DoesHaveBaseType_Should_ReturnTrue()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+        description.BaseTypes.Add("System.Object");
+
+        // Act
+        var implementsType = description.ImplementsType("System.Object");
+
+        // Assert
+        implementsType.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsType_DoesNotHaveBaseType_Should_ReturnFalse()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+        description.BaseTypes.Add("System.Object");
+
+        // Act
+        var implementsType = description.ImplementsType("System.Object2");
+
+        // Assert
+        implementsType.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsTypeStartsWith_DoesNotHaveAnyBaseTypes_Should_ReturnFalse()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+
+        // Act
+        var implementsType = description.ImplementsTypeStartsWith("System.Object");
+
+        // Assert
+        implementsType.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsTypeStartsWith_DoesHaveBaseType_Should_ReturnTrue()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+        description.BaseTypes.Add("System.Object");
+
+        // Act
+        var implementsType = description.ImplementsTypeStartsWith("System.");
+
+        // Assert
+        implementsType.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TypeDescription_ImplementsTypeStartsWith_DoesNotHaveBaseType_Should_ReturnFalse()
+    {
+        // Assign
+        var description = new TypeDescription(TypeType.Class, "Test");
+        description.BaseTypes.Add("System.Object");
+
+        // Act
+        var implementsType = description.ImplementsTypeStartsWith("SystemX.");
+
+        // Assert
+        implementsType.Should().BeFalse();
+    }
+
+    private class UnsupportedMemberDescription : MemberDescription
+    {
+        public UnsupportedMemberDescription(string name) : base(name)
+        {
         }
 
-        [TestMethod]
-        public void TypeDescription_GetHashCode_Should_ShouldBeTheSameForDifferentTypeTypes()
-        {
-            var descriptionX = new TypeDescription(TypeType.Class, "TestNamespace.TestClass").GetHashCode();
-            var descriptionY = new TypeDescription(TypeType.Interface, "TestNamespace.TestClass").GetHashCode();
-
-            descriptionX.Should().Be(descriptionY);
-        }
-
-        [TestMethod]
-        public void TypeDescription_GetHashCode_Should_DifferentNamesShouldDiffer()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass1").GetHashCode();
-            var descriptionY = new TypeDescription(0, "TestNamespace.TestClass2").GetHashCode();
-
-            descriptionX.Should().NotBe(descriptionY);
-        }
-
-        [TestMethod]
-        public void TypeDescription_Equals_Should_BeTrueForSameTypeDescriptions()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
-            var descriptionY = new TypeDescription(0, "TestNamespace.TestClass");
-
-            descriptionX.Equals(descriptionY).Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Equals_Should_BeFalseForDifferentCasing()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
-            var descriptionY = new TypeDescription(0, "testnamespace.testclass");
-
-            descriptionX.Equals(descriptionY).Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Equals_Should_BeFalseForDifferentTypeDescriptions()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass1");
-            var descriptionY = new TypeDescription(0, "TestNamespace.TestClass2");
-
-            descriptionX.Equals(descriptionY).Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Equals_Should_BeFalseForDifferentObjects()
-        {
-            var descriptionX = new TypeDescription(0, "TestNamespace.TestClass");
-            var descriptionY = new object();
-
-            descriptionX.Equals(descriptionY).Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Name_Should_BeFullNameIfThereAreNoDots()
-        {
-            var description = new TypeDescription(0, "TestClass");
-
-            description.Name.Should().Be("TestClass");
-        }
-
-        [TestMethod]
-        public void TypeDescription_Name_Should_BeParsedFromFullName()
-        {
-            var description = new TypeDescription(0, "TestNamespace.TestClass");
-
-            description.Name.Should().Be("TestClass");
-        }
-
-        [TestMethod]
-        public void TypeDescription_Namespace_Should_BeEmptyIfThereAreNoDots()
-        {
-            var description = new TypeDescription(0, "TestClass");
-
-            description.Namespace.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Namespace_Should_BeParsedFromFullName()
-        {
-            var description = new TypeDescription(0, "TestNamespace.TestClass");
-
-            description.Namespace.Should().Be("TestNamespace");
-        }
-
-        [TestMethod]
-        public void TypeDescription_Constructor_Should_SetFullName()
-        {
-            var description = new TypeDescription(0, "TestNamespace.TestClass");
-
-            description.FullName.Should().Be("TestNamespace.TestClass");
-        }
-
-        [TestMethod]
-        public void TypeDescription_Constructor_Should_SetFullNameEmptyIfNull()
-        {
-            var description = new TypeDescription(TypeType.Class, null);
-
-            description.FullName.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Constructor_Should_SetType()
-        {
-            var description = new TypeDescription(TypeType.Struct, null);
-
-            description.Type.Should().Be(TypeType.Struct);
-        }
-
-        [TestMethod]
-        public void TypeDescription_AddMember_Should_ThrowNotSupportedException()
-        {
-            var description = new TypeDescription(0, null);
-
-            Action action = () => { description.AddMember(new UnsupportedMemberDescription(null)); };
-
-            action.Should().Throw<NotSupportedException>();
-        }
-
-        [TestMethod]
-        public void TypeDescription_BaseTypes_Should_BeEmpty()
-        {
-            var description = new TypeDescription(0, null);
-
-            description.BaseTypes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TypeDescription_Attributes_Should_BeEmpty()
-        {
-            var description = new TypeDescription(0, null);
-
-            description.Attributes.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TypeDescription_MethodBodies_ConstuctorsAndMethodBodies_Should_BeReturnConcatenated()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-            var c = new ConstructorDescription("Test");
-            description.AddMember(c);
-            var m = new MethodDescription("void", "Method");
-            description.AddMember(m);
-
-            // Act
-            var bodies = description.MethodBodies();
-
-            // Assert
-            bodies.Should().AllBeAssignableTo<IHaveAMethodBody>();
-            bodies.Should().BeEquivalentTo(new IHaveAMethodBody[] { c, m });
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsType_DoesNotHaveAnyBaseTypes_Should_ReturnFalse()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-
-            // Act
-            var implementsType = description.ImplementsType("System.Object");
-
-            // Assert
-            implementsType.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsType_DoesHaveBaseType_Should_ReturnTrue()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-            description.BaseTypes.Add("System.Object");
-
-            // Act
-            var implementsType = description.ImplementsType("System.Object");
-
-            // Assert
-            implementsType.Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsType_DoesNotHaveBaseType_Should_ReturnFalse()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-            description.BaseTypes.Add("System.Object");
-
-            // Act
-            var implementsType = description.ImplementsType("System.Object2");
-
-            // Assert
-            implementsType.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsTypeStartsWith_DoesNotHaveAnyBaseTypes_Should_ReturnFalse()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-
-            // Act
-            var implementsType = description.ImplementsTypeStartsWith("System.Object");
-
-            // Assert
-            implementsType.Should().BeFalse();
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsTypeStartsWith_DoesHaveBaseType_Should_ReturnTrue()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-            description.BaseTypes.Add("System.Object");
-
-            // Act
-            var implementsType = description.ImplementsTypeStartsWith("System.");
-
-            // Assert
-            implementsType.Should().BeTrue();
-        }
-
-        [TestMethod]
-        public void TypeDescription_ImplementsTypeStartsWith_DoesNotHaveBaseType_Should_ReturnFalse()
-        {
-            // Assign
-            var description = new TypeDescription(TypeType.Class, "Test");
-            description.BaseTypes.Add("System.Object");
-
-            // Act
-            var implementsType = description.ImplementsTypeStartsWith("SystemX.");
-
-            // Assert
-            implementsType.Should().BeFalse();
-        }
-
-        private class UnsupportedMemberDescription : MemberDescription
-        {
-            public UnsupportedMemberDescription(string name) : base(name)
-            {
-            }
-
-            public override MemberType MemberType => throw new NotImplementedException();
-        }
+        public override MemberType MemberType => throw new NotImplementedException();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/DocumentationCommentsDescriptionTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/DocumentationCommentsDescriptionTests.cs
@@ -1,60 +1,55 @@
-﻿using FluentAssertions;
-using FluentAssertions.Execution;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class DocumentationCommentsDescriptionTests
 {
-    [TestClass]
-    public class DocumentationCommentsDescriptionTests
+    [TestMethod]
+    public void DefaultDocumentationSummary_Should_NotBeNull()
     {
-        [TestMethod]
-        public void DefaultDocumentationSummary_Should_NotBeNull()
-        {
-            // Assign
-            var documentation = new DocumentationCommentsDescription();
+        // Assign
+        var documentation = new DocumentationCommentsDescription();
 
-            // Assert
-            documentation.Summary.Should().NotBeNull();
-        }
+        // Assert
+        documentation.Summary.Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void DefaultDocumentationReturns_Should_NotBeNull()
-        {
-            // Assign
-            var documentation = new DocumentationCommentsDescription();
+    [TestMethod]
+    public void DefaultDocumentationReturns_Should_NotBeNull()
+    {
+        // Assign
+        var documentation = new DocumentationCommentsDescription();
 
-            // Assert
-            documentation.Returns.Should().NotBeNull();
-        }
+        // Assert
+        documentation.Returns.Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void DefaultDocumentationRemarks_Should_NotBeNull()
-        {
-            // Assign
-            var documentation = new DocumentationCommentsDescription();
+    [TestMethod]
+    public void DefaultDocumentationRemarks_Should_NotBeNull()
+    {
+        // Assign
+        var documentation = new DocumentationCommentsDescription();
 
-            // Assert
-            documentation.Remarks.Should().NotBeNull();
-        }
+        // Assert
+        documentation.Remarks.Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void DefaultDocumentationValue_Should_NotBeNull()
-        {
-            // Assign
-            var documentation = new DocumentationCommentsDescription();
+    [TestMethod]
+    public void DefaultDocumentationValue_Should_NotBeNull()
+    {
+        // Assign
+        var documentation = new DocumentationCommentsDescription();
 
-            // Assert
-            documentation.Value.Should().NotBeNull();
-        }
+        // Assert
+        documentation.Value.Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void DefaultDocumentationExample_Should_NotBeNull()
-        {
-            // Assign
-            var documentation = new DocumentationCommentsDescription();
+    [TestMethod]
+    public void DefaultDocumentationExample_Should_NotBeNull()
+    {
+        // Assign
+        var documentation = new DocumentationCommentsDescription();
 
-            // Assert
-            documentation.Example.Should().NotBeNull();
-        }
+        // Assert
+        documentation.Example.Should().NotBeNull();
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/DocumentationCommentsTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/DocumentationCommentsTests.cs
@@ -1,19 +1,48 @@
-﻿using FluentAssertions;
-using FluentAssertions.Execution;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class DocumentationCommentsTests
 {
-    [TestClass]
-    public class DocumentationCommentsTests
+    [TestMethod]
+    public void ClassWithComments_Should_HaveDocumentationParsed()
     {
-        [TestMethod]
-        public void ClassWithComments_Should_HaveDocumentationParsed()
+        // Assign
+        var source = @"
+        /// <summary>
+        /// This is a Test Class.
+        /// </summary>
+        /// <remarks>
+        /// This is a remark.
+        /// </remarks>
+        /// <example>
+        /// This is an example.
+        /// </example>
+        class Test
         {
-            // Assign
-            var source = @"
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].DocumentationComments.Summary.Should().Be("This is a Test Class.");
+            types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].DocumentationComments.Example.Should().Be("This is an example.");
+        }
+    }
+
+    [TestMethod]
+    public void EventWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
             /// <summary>
-            /// This is a Test Class.
+            /// This is a Test Event.
             /// </summary>
             /// <remarks>
             /// This is a remark.
@@ -21,188 +50,37 @@ namespace LivingDocumentation.Analyzer.Tests
             /// <example>
             /// This is an example.
             /// </example>
-            class Test
-            {
-            }
-            ";
+            /// <value>
+            /// This is the value.
+            /// </value>
+            event System.Action @event;
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].DocumentationComments.Summary.Should().Be("This is a Test Class.");
-                types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].DocumentationComments.Example.Should().Be("This is an example.");
-            }
+            Test() { @event(); }
         }
+        ";
 
-        [TestMethod]
-        public void EventWithComments_Should_HaveDocumentationParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// This is a Test Event.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <value>
-                /// This is the value.
-                /// </value>
-                event System.Action @event;
-
-                Test() { @event(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Events[0].DocumentationComments.Summary.Should().Be("This is a Test Event.");
-                types[0].Events[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Events[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Events[0].DocumentationComments.Value.Should().Be("This is the value.");
-            }
+            types[0].Events[0].DocumentationComments.Summary.Should().Be("This is a Test Event.");
+            types[0].Events[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Events[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Events[0].DocumentationComments.Value.Should().Be("This is the value.");
         }
+    }
 
-        [TestMethod]
-        public void MultipleEventDeclarationsWithComments_Should_HaveDocumentationParsedForEveryEvent()
+    [TestMethod]
+    public void MultipleEventDeclarationsWithComments_Should_HaveDocumentationParsedForEveryEvent()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// These are Test Events.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <value>
-                /// This is the value.
-                /// </value>
-                event System.Action event1, event2;
-
-                Test() { event1(); event2(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Events[0].DocumentationComments.Summary.Should().Be("These are Test Events.");
-                types[0].Events[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Events[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Events[0].DocumentationComments.Value.Should().Be("This is the value.");
-
-                types[0].Events[1].DocumentationComments.Summary.Should().Be("These are Test Events.");
-                types[0].Events[1].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Events[1].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Events[1].DocumentationComments.Value.Should().Be("This is the value.");
-            }
-        }
-
-        [TestMethod]
-        public void FieldWithComments_Should_HaveDocumentationParsed()
-        {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                /// <summary>
-                /// This is a Test Field.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <value>
-                /// This is the value.
-                /// </value>
-                public string field;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Fields[0].DocumentationComments.Summary.Should().Be("This is a Test Field.");
-                types[0].Fields[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Fields[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Fields[0].DocumentationComments.Value.Should().Be("This is the value.");
-            }
-        }
-
-        [TestMethod]
-        public void MultipleFieldDeclarationsWithComments_Should_HaveDocumentationParsedForEveryField()
-        {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                /// <summary>
-                /// These are Test Fields.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <value>
-                /// This is the value.
-                /// </value>
-                public string field1, field2;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Fields[0].DocumentationComments.Summary.Should().Be("These are Test Fields.");
-                types[0].Fields[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Fields[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Fields[0].DocumentationComments.Value.Should().Be("This is the value.");
-
-                types[0].Fields[1].DocumentationComments.Summary.Should().Be("These are Test Fields.");
-                types[0].Fields[1].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Fields[1].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Fields[1].DocumentationComments.Value.Should().Be("This is the value.");
-            }
-        }
-
-        [TestMethod]
-        public void InterfaceWithComments_Should_HaveDocumentationParsed()
-        {
-            // Assign
-            var source = @"
             /// <summary>
-            /// This is a Test Interface.
+            /// These are Test Events.
             /// </summary>
             /// <remarks>
             /// This is a remark.
@@ -210,30 +88,42 @@ namespace LivingDocumentation.Analyzer.Tests
             /// <example>
             /// This is an example.
             /// </example>
-            interface Test
-            {
-            }
-            ";
+            /// <value>
+            /// This is the value.
+            /// </value>
+            event System.Action event1, event2;
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].DocumentationComments.Summary.Should().Be("This is a Test Interface.");
-                types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].DocumentationComments.Example.Should().Be("This is an example.");
-            }
+            Test() { event1(); event2(); }
         }
+        ";
 
-        [TestMethod]
-        public void EnumWithComments_Should_HaveDocumentationParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
         {
-            // Assign
-            var source = @"
+            types[0].Events[0].DocumentationComments.Summary.Should().Be("These are Test Events.");
+            types[0].Events[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Events[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Events[0].DocumentationComments.Value.Should().Be("This is the value.");
+
+            types[0].Events[1].DocumentationComments.Summary.Should().Be("These are Test Events.");
+            types[0].Events[1].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Events[1].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Events[1].DocumentationComments.Value.Should().Be("This is the value.");
+        }
+    }
+
+    [TestMethod]
+    public void FieldWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
             /// <summary>
-            /// This is a Test Enum.
+            /// This is a Test Field.
             /// </summary>
             /// <remarks>
             /// This is a remark.
@@ -241,30 +131,35 @@ namespace LivingDocumentation.Analyzer.Tests
             /// <example>
             /// This is an example.
             /// </example>
-            enum Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].DocumentationComments.Summary.Should().Be("This is a Test Enum.");
-                types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].DocumentationComments.Example.Should().Be("This is an example.");
-            }
+            /// <value>
+            /// This is the value.
+            /// </value>
+            public string field;
         }
+        ";
 
-        [TestMethod]
-        public void StructWithComments_Should_HaveDocumentationParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
         {
-            // Assign
-            var source = @"
+            types[0].Fields[0].DocumentationComments.Summary.Should().Be("This is a Test Field.");
+            types[0].Fields[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Fields[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Fields[0].DocumentationComments.Value.Should().Be("This is the value.");
+        }
+    }
+
+    [TestMethod]
+    public void MultipleFieldDeclarationsWithComments_Should_HaveDocumentationParsedForEveryField()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
             /// <summary>
-            /// This is a Test Struct.
+            /// These are Test Fields.
             /// </summary>
             /// <remarks>
             /// This is a remark.
@@ -272,129 +167,229 @@ namespace LivingDocumentation.Analyzer.Tests
             /// <example>
             /// This is an example.
             /// </example>
-            struct Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].DocumentationComments.Summary.Should().Be("This is a Test Struct.");
-                types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].DocumentationComments.Example.Should().Be("This is an example.");
-            }
+            /// <value>
+            /// This is the value.
+            /// </value>
+            public string field1, field2;
         }
+        ";
 
-        [TestMethod]
-        public void MethodWithComments_Should_HaveDocumentationParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// This is a Test Method.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <returns>
-                /// Returns a string.
-                /// </returns>
-                public string Method() { return null; }
-            }
-            ";
+            types[0].Fields[0].DocumentationComments.Summary.Should().Be("These are Test Fields.");
+            types[0].Fields[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Fields[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Fields[0].DocumentationComments.Value.Should().Be("This is the value.");
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Summary.Should().Be("This is a Test Method.");
-                types[0].Methods[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Methods[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Methods[0].DocumentationComments.Returns.Should().Be("Returns a string.");
-            }
+            types[0].Fields[1].DocumentationComments.Summary.Should().Be("These are Test Fields.");
+            types[0].Fields[1].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Fields[1].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Fields[1].DocumentationComments.Value.Should().Be("This is the value.");
         }
+    }
 
-        [TestMethod]
-        public void ConstructorWithComments_Should_HaveDocumentationParsed()
+    [TestMethod]
+    public void InterfaceWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// This is a Test Interface.
+        /// </summary>
+        /// <remarks>
+        /// This is a remark.
+        /// </remarks>
+        /// <example>
+        /// This is an example.
+        /// </example>
+        interface Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// This is a Test Constructor.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <returns>
-                /// Returns a string.
-                /// </returns>
-                Test() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Constructors[0].DocumentationComments.Summary.Should().Be("This is a Test Constructor.");
-                types[0].Constructors[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Constructors[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Constructors[0].DocumentationComments.Returns.Should().Be("Returns a string.");
-            }
         }
+        ";
 
-        [TestMethod]
-        public void PropertyWithComments_Should_HaveDocumentationParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// This is a Test Property.
-                /// </summary>
-                /// <remarks>
-                /// This is a remark.
-                /// </remarks>
-                /// <example>
-                /// This is an example.
-                /// </example>
-                /// <value>
-                /// This is the value.
-                /// </value>
-                public string Property { get; set; }
-            }
-            ";
+            types[0].DocumentationComments.Summary.Should().Be("This is a Test Interface.");
+            types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].DocumentationComments.Example.Should().Be("This is an example.");
+        }
+    }
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
+    [TestMethod]
+    public void EnumWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// This is a Test Enum.
+        /// </summary>
+        /// <remarks>
+        /// This is a remark.
+        /// </remarks>
+        /// <example>
+        /// This is an example.
+        /// </example>
+        enum Test
+        {
+        }
+        ";
 
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Properties[0].DocumentationComments.Summary.Should().Be("This is a Test Property.");
-                types[0].Properties[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
-                types[0].Properties[0].DocumentationComments.Example.Should().Be("This is an example.");
-                types[0].Properties[0].DocumentationComments.Value.Should().Be("This is the value.");
-            }
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].DocumentationComments.Summary.Should().Be("This is a Test Enum.");
+            types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].DocumentationComments.Example.Should().Be("This is an example.");
+        }
+    }
+
+    [TestMethod]
+    public void StructWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// This is a Test Struct.
+        /// </summary>
+        /// <remarks>
+        /// This is a remark.
+        /// </remarks>
+        /// <example>
+        /// This is an example.
+        /// </example>
+        struct Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].DocumentationComments.Summary.Should().Be("This is a Test Struct.");
+            types[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].DocumentationComments.Example.Should().Be("This is an example.");
+        }
+    }
+
+    [TestMethod]
+    public void MethodWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// This is a Test Method.
+            /// </summary>
+            /// <remarks>
+            /// This is a remark.
+            /// </remarks>
+            /// <example>
+            /// This is an example.
+            /// </example>
+            /// <returns>
+            /// Returns a string.
+            /// </returns>
+            public string Method() { return null; }
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Summary.Should().Be("This is a Test Method.");
+            types[0].Methods[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Methods[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Methods[0].DocumentationComments.Returns.Should().Be("Returns a string.");
+        }
+    }
+
+    [TestMethod]
+    public void ConstructorWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// This is a Test Constructor.
+            /// </summary>
+            /// <remarks>
+            /// This is a remark.
+            /// </remarks>
+            /// <example>
+            /// This is an example.
+            /// </example>
+            /// <returns>
+            /// Returns a string.
+            /// </returns>
+            Test() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Constructors[0].DocumentationComments.Summary.Should().Be("This is a Test Constructor.");
+            types[0].Constructors[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Constructors[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Constructors[0].DocumentationComments.Returns.Should().Be("Returns a string.");
+        }
+    }
+
+    [TestMethod]
+    public void PropertyWithComments_Should_HaveDocumentationParsed()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// This is a Test Property.
+            /// </summary>
+            /// <remarks>
+            /// This is a remark.
+            /// </remarks>
+            /// <example>
+            /// This is an example.
+            /// </example>
+            /// <value>
+            /// This is the value.
+            /// </value>
+            public string Property { get; set; }
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Properties[0].DocumentationComments.Summary.Should().Be("This is a Test Property.");
+            types[0].Properties[0].DocumentationComments.Remarks.Should().Be("This is a remark.");
+            types[0].Properties[0].DocumentationComments.Example.Should().Be("This is an example.");
+            types[0].Properties[0].DocumentationComments.Value.Should().Be("This is the value.");
         }
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/DocumentationTagContentParsingTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/DocumentationTagContentParsingTests.cs
@@ -1,841 +1,836 @@
-﻿using FluentAssertions;
-using FluentAssertions.Execution;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class DocumentationTagContentParsingTests
 {
-    [TestClass]
-    public class DocumentationTagContentParsingTests
+    [TestMethod]
+    public void Summary_Should_BeRead()
     {
-        [TestMethod]
-        public void Summary_Should_BeRead()
+        // Assign
+        var source = @"
+        /// <summary>
+        /// A summary.
+        /// </summary>
+        class Test
         {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// A summary.
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("A summary.");
         }
+        ";
 
-        [TestMethod]
-        public void Remarks_Should_BeRead()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("A summary.");
+    }
+
+    [TestMethod]
+    public void Remarks_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        /// <remarks>
+        /// A remark.
+        /// </remarks>
+        class Test
         {
-            // Assign
-            var source = @"
-            /// <remarks>
-            /// A remark.
-            /// </remarks>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Remarks.Should().Be("A remark.");
         }
+        ";
 
-        [TestMethod]
-        public void Example_Should_BeRead()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Remarks.Should().Be("A remark.");
+    }
+
+    [TestMethod]
+    public void Example_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <example>
-                /// The following example demonstrates the use of this method.
-                /// 
-                /// <code>
-                /// // Get a new random number
-                /// SampleClass sc = new SampleClass(10);
-                /// 
-                /// int random = sc.GetRandomNumber();
-                ///
-                /// Console.WriteLine(""Random value: {0}"", random);
-                /// </code>
-                /// </example>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].DocumentationComments.Example.Should().Be("The following example demonstrates the use of this method.\n\n// Get a new random number\nSampleClass sc = new SampleClass(10);\n\nint random = sc.GetRandomNumber();\n\nConsole.WriteLine(\"Random value: {0}\", random);");
-        }
-
-
-        [TestMethod]
-        public void Exception_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <exception cref=""System.Exception"">An exception.</exception>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Exceptions.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.Exception", "An exception."); 
-            }
-        }
-
-        [TestMethod]
-        public void Exceptions_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <exception cref=""System.Exception"">An exception.</exception>
-                /// <exception cref=""System.StackOverflowException"">Another exception.</exception>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Exceptions.Should().HaveCount(2);
-                types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.Exception", "An exception.");
-                types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.StackOverflowException", "Another exception.");
-            }
-        }
-
-        [TestMethod]
-        public void Param_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <param name=""param"">This is a param.</param>
-                void Method(string param) {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Params.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.Params.Should().Contain("param", "This is a param.");
-            }
-        }
-
-        [TestMethod]
-        public void Params_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <param name=""param1"">This is the first parameter.</param>
-                /// <param name=""param2"">This is the second parameter.</param>
-                void Method(string param1, string param2) {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Params.Should().HaveCount(2);
-                types[0].Methods[0].DocumentationComments.Params.Should().Contain("param1", "This is the first parameter.");
-                types[0].Methods[0].DocumentationComments.Params.Should().Contain("param2", "This is the second parameter.");
-            }
-        }
-
-        [TestMethod]
-        public void Permission_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <permission cref=""System.Security.PermissionSet"">A permission.</permission>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Permissions.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.PermissionSet", "A permission.");
-            }
-        }
-
-        [TestMethod]
-        public void Permissions_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <permission cref=""System.Security.Permissions.EnvironmentPermission"">A permission.</permission>
-                /// <permission cref=""System.Security.Permissions.FileIOPermission"">Another permission.</permission>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.Permissions.Should().HaveCount(2);
-                types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.Permissions.EnvironmentPermission", "A permission.");
-                types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.Permissions.FileIOPermission", "Another permission.");
-            }
-        }
-
-        [TestMethod]
-        public void SeeAlso_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <seealso cref=""System.String"" />
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.String", "System.String");
-            }
-        }
-
-        [TestMethod]
-        public void SeeAlsos_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <seealso cref=""System.String"" />
-                /// <seealso cref=""System.Object"">See also.</seealso>
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(2);
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.String", "System.String");
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.Object", "See also.");
-            }
-        }
-
-        [TestMethod]
-        public void TypeParam_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <typeparam name=""T"">This is a type param.</typeparam>
-                void Method<T>() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.TypeParams.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T", "This is a type param.");
-            }
-        }
-
-        [TestMethod]
-        public void TypeParams_Should_BeRead()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <typeparam name=""T1"">This is the first type parameter.</typeparam>
-                /// <typeparam name=""T2"">This is the second type parameter.</typeparam>
-                void Method<T1, T2>() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.TypeParams.Should().HaveCount(2);
-                types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T1", "This is the first type parameter.");
-                types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T2", "This is the second type parameter.");
-            }
-        }
-
-        [TestMethod]
-        public void SummaryWithWhitespace_Should_BeTrimmed()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
+            /// <example>
+            /// The following example demonstrates the use of this method.
             /// 
-            ///   A  
-            ///   
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("A");
-        }
-
-        [TestMethod]
-        public void NonSummaryWithWhitespace_Should_OnlyNonNewLinesBeTrimmed()
-        {
-            // Assign
-            var source = @"
-            /// <remarks>
-            ///   A  
-            ///   B
-            /// </remarks>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Remarks.Should().Be("A\nB");
-        }
-
-        [TestMethod]
-        public void TagWithSeeAlso_Should_IgnoreSeeAlso()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// <seealso cref=""System.Object"">See also.</seealso>
-                /// </summary>
-                public void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].DocumentationComments.Summary.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void TagWithSeeAlso_Should_AddToSeeAlsos()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// <seealso cref=""System.Object"">See also.</seealso>
-                /// </summary>
-                public void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(1);
-                types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.Object", "See also.");
-            }
-        }
-
-        [TestMethod]
-        public void TagWithParamRefName_Should_HaveNameAsComment()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// A <paramref name=""b"" /> c
-                /// </summary>
-                public void Method(string b) {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].DocumentationComments.Summary.Should().Be("A b c");
-        }
-
-        [TestMethod]
-        public void TagWithTypeParamRefName_Should_HaveNameAsComment()
-        {
-            // Assign
-            var source = @"
-            class Test
-            {
-                /// <summary>
-                /// A <typeparamref name=""b""/> c
-                /// </summary>
-                public void Method<b>() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].DocumentationComments.Summary.Should().Be("A b c");
-        }
-
-        [TestMethod]
-        public void SummaryWithLineBreaksBetweenText_Should_HaveOnlySingleSpaceBetweenText()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// a
-            /// 
-            /// b
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("a b");
-        }
-
-        [TestMethod]
-        public void SummaryWithMixOfTextAndPara_Should_HaveALineBreakBetweenText()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// a
-            /// <para>b</para>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("a\nb");
-        }
-
-        [TestMethod]
-        public void SummaryWithMultipleParas_Should_HaveLinebreakBetweenText()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <para>a</para>
-            /// <para>b</para>
-            /// <para>c</para>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("a\nb\nc");
-        }
-
-        [TestMethod]
-        public void TagWithSeeWithInnertext_Should_HaveInnerTextAsComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// A <see cref=""Test"">b</see> c
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("A b c");
-        }
-
-        [TestMethod]
-        public void TagWithSee_Should_HaveCrefAsComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// A <see cref=""b"" /> c
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("A b c");
-        }
-
-        [TestMethod]
-        public void TagWithCode_Should_HaveInnerTextAsComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// A <c>b</c> c
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("A b c");
-        }
-
-        [TestMethod]
-        public void TagWithInvalidList_Should_HaveListItemsAsInlineTextInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list>
-            /// <item>First item</item>
-            /// <item>Second item</item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("First item Second item");
-        }
-
-        [TestMethod]
-        public void TagWithBulletList_Should_HaveListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""bullet"">
-            /// <item>First item</item>
-            /// <item>Second item</item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("* First item\n* Second item");
-        }
-
-        [TestMethod]
-        public void TagWithBulletListWithDescriptions_Should_HaveListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""bullet"">
-            /// <item><description>First item</description></item>
-            /// <item><description>Second item</description></item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("* First item\n* Second item");
-        }
-
-        [TestMethod]
-        public void TagWithBulletListWithTermsAndDescriptions_Should_HaveListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""bullet"">
-            /// <item>
-            /// <term>Term 1</term>
-            /// <description>First item</description>
-            /// </item>
-            /// <item>
-            /// <term>Term 2</term>
-            /// <description>Second item</description>
-            /// </item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("* Term 1 - First item\n* Term 2 - Second item");
-        }
-
-
-
-        [TestMethod]
-        public void TagWithNumberedList_Should_HaveNumberedListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""number"">
-            /// <item>First item</item>
-            /// <item>Second item</item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("1. First item\n2. Second item");
-        }
-
-        [TestMethod]
-        public void TagWithNumberedListWithStart_Should_HaveCorrectNumberedListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""number"" start=""3"">
-            /// <item>First item</item>
-            /// <item>Second item</item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("3. First item\n4. Second item");
-        }
-
-        [TestMethod]
-        public void TagWithNumberedListWithDescriptions_Should_HaveNumberedListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""number"">
-            /// <item><description>First item</description></item>
-            /// <item><description>Second item</description></item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("1. First item\n2. Second item");
-        }
-
-        [TestMethod]
-        public void TagWithNumberedListWithTermsAndDescriptions_Should_HaveNumberedListItemsAsLinesInComment()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""number"">
-            /// <item>
-            /// <term>Term 1</term>
-            /// <description>First item</description>
-            /// </item>
-            /// <item>
-            /// <term>Term 2</term>
-            /// <description>Second item</description>
-            /// </item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("1. Term 1 - First item\n2. Term 2 - Second item");
-        }
-
-        [TestMethod]
-        public void TagWithDefinitionListWithTermsAndDescriptions_Should_HaveSeperateLinesWithTermAndDescriptionIndented()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// <list type=""definition"">
-            /// <item>
-            /// <term>Term 1</term>
-            /// <description>First item</description>
-            /// </item>
-            /// <item>
-            /// <term>Term 2</term>
-            /// <description>Second item</description>
-            /// </item>
-            /// </list>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("Term 1\n    First item\nTerm 2\n    Second item");
-        }
-
-        [TestMethod]
-        public void TagWithNestedContent_Should_RenderCorrectly()
-        {
-            // Assign
-            var source = @"
-            /// <summary>
-            /// This is a summary with mixed content.
-            /// <para>A <see cref=""System.Object"">paragraph</see></para>
-            /// <para>Another <paramref name=""paragraph""/></para>
-            /// <list type=""definition"">
-            /// <item>
-            /// <term>Term 1</term>
-            /// <description>First <typeparamref name=""item""/></description>
-            /// </item>
-            /// <item>
-            /// <term>Term <c>2</c></term>
-            /// <description><para>Second item</para></description>
-            /// </item>
-            /// </list>
             /// <code>
-            /// class ACodeSample { }
+            /// // Get a new random number
+            /// SampleClass sc = new SampleClass(10);
+            /// 
+            /// int random = sc.GetRandomNumber();
+            ///
+            /// Console.WriteLine(""Random value: {0}"", random);
             /// </code>
-            /// More text <c>null</c> and more text
-            /// <seealso cref=""System.Object""/>
-            /// </summary>
-            class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].DocumentationComments.Summary.Should().Be("This is a summary with mixed content.\nA paragraph\nAnother paragraph\nTerm 1\n    First item\nTerm 2\n    Second item\nclass ACodeSample { }\nMore text null and more text");
+            /// </example>
+            void Method() {}
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].DocumentationComments.Example.Should().Be("The following example demonstrates the use of this method.\n\n// Get a new random number\nSampleClass sc = new SampleClass(10);\n\nint random = sc.GetRandomNumber();\n\nConsole.WriteLine(\"Random value: {0}\", random);");
+    }
+
+
+    [TestMethod]
+    public void Exception_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <exception cref=""System.Exception"">An exception.</exception>
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Exceptions.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.Exception", "An exception."); 
+        }
+    }
+
+    [TestMethod]
+    public void Exceptions_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <exception cref=""System.Exception"">An exception.</exception>
+            /// <exception cref=""System.StackOverflowException"">Another exception.</exception>
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Exceptions.Should().HaveCount(2);
+            types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.Exception", "An exception.");
+            types[0].Methods[0].DocumentationComments.Exceptions.Should().Contain("System.StackOverflowException", "Another exception.");
+        }
+    }
+
+    [TestMethod]
+    public void Param_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <param name=""param"">This is a param.</param>
+            void Method(string param) {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Params.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.Params.Should().Contain("param", "This is a param.");
+        }
+    }
+
+    [TestMethod]
+    public void Params_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <param name=""param1"">This is the first parameter.</param>
+            /// <param name=""param2"">This is the second parameter.</param>
+            void Method(string param1, string param2) {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Params.Should().HaveCount(2);
+            types[0].Methods[0].DocumentationComments.Params.Should().Contain("param1", "This is the first parameter.");
+            types[0].Methods[0].DocumentationComments.Params.Should().Contain("param2", "This is the second parameter.");
+        }
+    }
+
+    [TestMethod]
+    public void Permission_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <permission cref=""System.Security.PermissionSet"">A permission.</permission>
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Permissions.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.PermissionSet", "A permission.");
+        }
+    }
+
+    [TestMethod]
+    public void Permissions_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <permission cref=""System.Security.Permissions.EnvironmentPermission"">A permission.</permission>
+            /// <permission cref=""System.Security.Permissions.FileIOPermission"">Another permission.</permission>
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.Permissions.Should().HaveCount(2);
+            types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.Permissions.EnvironmentPermission", "A permission.");
+            types[0].Methods[0].DocumentationComments.Permissions.Should().Contain("System.Security.Permissions.FileIOPermission", "Another permission.");
+        }
+    }
+
+    [TestMethod]
+    public void SeeAlso_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <seealso cref=""System.String"" />
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.String", "System.String");
+        }
+    }
+
+    [TestMethod]
+    public void SeeAlsos_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <seealso cref=""System.String"" />
+            /// <seealso cref=""System.Object"">See also.</seealso>
+            void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(2);
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.String", "System.String");
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.Object", "See also.");
+        }
+    }
+
+    [TestMethod]
+    public void TypeParam_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <typeparam name=""T"">This is a type param.</typeparam>
+            void Method<T>() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.TypeParams.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T", "This is a type param.");
+        }
+    }
+
+    [TestMethod]
+    public void TypeParams_Should_BeRead()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <typeparam name=""T1"">This is the first type parameter.</typeparam>
+            /// <typeparam name=""T2"">This is the second type parameter.</typeparam>
+            void Method<T1, T2>() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.TypeParams.Should().HaveCount(2);
+            types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T1", "This is the first type parameter.");
+            types[0].Methods[0].DocumentationComments.TypeParams.Should().Contain("T2", "This is the second type parameter.");
+        }
+    }
+
+    [TestMethod]
+    public void SummaryWithWhitespace_Should_BeTrimmed()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// 
+        ///   A  
+        ///   
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("A");
+    }
+
+    [TestMethod]
+    public void NonSummaryWithWhitespace_Should_OnlyNonNewLinesBeTrimmed()
+    {
+        // Assign
+        var source = @"
+        /// <remarks>
+        ///   A  
+        ///   B
+        /// </remarks>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Remarks.Should().Be("A\nB");
+    }
+
+    [TestMethod]
+    public void TagWithSeeAlso_Should_IgnoreSeeAlso()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// <seealso cref=""System.Object"">See also.</seealso>
+            /// </summary>
+            public void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].DocumentationComments.Summary.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TagWithSeeAlso_Should_AddToSeeAlsos()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// <seealso cref=""System.Object"">See also.</seealso>
+            /// </summary>
+            public void Method() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().HaveCount(1);
+            types[0].Methods[0].DocumentationComments.SeeAlsos.Should().Contain("System.Object", "See also.");
+        }
+    }
+
+    [TestMethod]
+    public void TagWithParamRefName_Should_HaveNameAsComment()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// A <paramref name=""b"" /> c
+            /// </summary>
+            public void Method(string b) {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].DocumentationComments.Summary.Should().Be("A b c");
+    }
+
+    [TestMethod]
+    public void TagWithTypeParamRefName_Should_HaveNameAsComment()
+    {
+        // Assign
+        var source = @"
+        class Test
+        {
+            /// <summary>
+            /// A <typeparamref name=""b""/> c
+            /// </summary>
+            public void Method<b>() {}
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].DocumentationComments.Summary.Should().Be("A b c");
+    }
+
+    [TestMethod]
+    public void SummaryWithLineBreaksBetweenText_Should_HaveOnlySingleSpaceBetweenText()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// a
+        /// 
+        /// b
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("a b");
+    }
+
+    [TestMethod]
+    public void SummaryWithMixOfTextAndPara_Should_HaveALineBreakBetweenText()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// a
+        /// <para>b</para>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("a\nb");
+    }
+
+    [TestMethod]
+    public void SummaryWithMultipleParas_Should_HaveLinebreakBetweenText()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <para>a</para>
+        /// <para>b</para>
+        /// <para>c</para>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("a\nb\nc");
+    }
+
+    [TestMethod]
+    public void TagWithSeeWithInnertext_Should_HaveInnerTextAsComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// A <see cref=""Test"">b</see> c
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("A b c");
+    }
+
+    [TestMethod]
+    public void TagWithSee_Should_HaveCrefAsComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// A <see cref=""b"" /> c
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("A b c");
+    }
+
+    [TestMethod]
+    public void TagWithCode_Should_HaveInnerTextAsComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// A <c>b</c> c
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("A b c");
+    }
+
+    [TestMethod]
+    public void TagWithInvalidList_Should_HaveListItemsAsInlineTextInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list>
+        /// <item>First item</item>
+        /// <item>Second item</item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("First item Second item");
+    }
+
+    [TestMethod]
+    public void TagWithBulletList_Should_HaveListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""bullet"">
+        /// <item>First item</item>
+        /// <item>Second item</item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("* First item\n* Second item");
+    }
+
+    [TestMethod]
+    public void TagWithBulletListWithDescriptions_Should_HaveListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""bullet"">
+        /// <item><description>First item</description></item>
+        /// <item><description>Second item</description></item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("* First item\n* Second item");
+    }
+
+    [TestMethod]
+    public void TagWithBulletListWithTermsAndDescriptions_Should_HaveListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""bullet"">
+        /// <item>
+        /// <term>Term 1</term>
+        /// <description>First item</description>
+        /// </item>
+        /// <item>
+        /// <term>Term 2</term>
+        /// <description>Second item</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("* Term 1 - First item\n* Term 2 - Second item");
+    }
+
+
+
+    [TestMethod]
+    public void TagWithNumberedList_Should_HaveNumberedListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""number"">
+        /// <item>First item</item>
+        /// <item>Second item</item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("1. First item\n2. Second item");
+    }
+
+    [TestMethod]
+    public void TagWithNumberedListWithStart_Should_HaveCorrectNumberedListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""number"" start=""3"">
+        /// <item>First item</item>
+        /// <item>Second item</item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("3. First item\n4. Second item");
+    }
+
+    [TestMethod]
+    public void TagWithNumberedListWithDescriptions_Should_HaveNumberedListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""number"">
+        /// <item><description>First item</description></item>
+        /// <item><description>Second item</description></item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("1. First item\n2. Second item");
+    }
+
+    [TestMethod]
+    public void TagWithNumberedListWithTermsAndDescriptions_Should_HaveNumberedListItemsAsLinesInComment()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""number"">
+        /// <item>
+        /// <term>Term 1</term>
+        /// <description>First item</description>
+        /// </item>
+        /// <item>
+        /// <term>Term 2</term>
+        /// <description>Second item</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("1. Term 1 - First item\n2. Term 2 - Second item");
+    }
+
+    [TestMethod]
+    public void TagWithDefinitionListWithTermsAndDescriptions_Should_HaveSeperateLinesWithTermAndDescriptionIndented()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// <list type=""definition"">
+        /// <item>
+        /// <term>Term 1</term>
+        /// <description>First item</description>
+        /// </item>
+        /// <item>
+        /// <term>Term 2</term>
+        /// <description>Second item</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("Term 1\n    First item\nTerm 2\n    Second item");
+    }
+
+    [TestMethod]
+    public void TagWithNestedContent_Should_RenderCorrectly()
+    {
+        // Assign
+        var source = @"
+        /// <summary>
+        /// This is a summary with mixed content.
+        /// <para>A <see cref=""System.Object"">paragraph</see></para>
+        /// <para>Another <paramref name=""paragraph""/></para>
+        /// <list type=""definition"">
+        /// <item>
+        /// <term>Term 1</term>
+        /// <description>First <typeparamref name=""item""/></description>
+        /// </item>
+        /// <item>
+        /// <term>Term <c>2</c></term>
+        /// <description><para>Second item</para></description>
+        /// </item>
+        /// </list>
+        /// <code>
+        /// class ACodeSample { }
+        /// </code>
+        /// More text <c>null</c> and more text
+        /// <seealso cref=""System.Object""/>
+        /// </summary>
+        class Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].DocumentationComments.Summary.Should().Be("This is a summary with mixed content.\nA paragraph\nAnother paragraph\nTerm 1\n    First item\nTerm 2\n    Second item\nclass ACodeSample { }\nMore text null and more text");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/EnumModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/EnumModifierTests.cs
@@ -1,61 +1,57 @@
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class EnumModifierTests
 {
-    [TestClass]
-    public class EnumModifierTests
+    [TestMethod]
+    public void EnumWithoutModifier_Should_HaveDefaultInternalModifier()
     {
-        [TestMethod]
-        public void EnumWithoutModifier_Should_HaveDefaultInternalModifier()
+        // Assign
+        var source = @"
+        enum Test
         {
-            // Assign
-            var source = @"
-            enum Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Internal);
         }
+        ";
 
-        [TestMethod]
-        public void PublicEnum_Should_HavePublicModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Internal);
+    }
+
+    [TestMethod]
+    public void PublicEnum_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        public enum Test
         {
-            // Assign
-            var source = @"
-            public enum Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Public);
         }
+        ";
 
-        [TestMethod]
-        public void EnumMembers_Should_HavePublicModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Public);
+    }
+
+    [TestMethod]
+    public void EnumMembers_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        public enum Test
         {
-            // Assign
-            var source = @"
-            public enum Test
-            {
-                Value
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].EnumMembers[0].Modifiers.Should().Be(Modifier.Public);
+            Value
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].EnumMembers[0].Modifiers.Should().Be(Modifier.Public);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/EventDeclarationTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/EventDeclarationTests.cs
@@ -3,63 +3,94 @@ namespace LivingDocumentation.Analyzer.Tests;
 [TestClass]
 public class EventDeclarationTests
 {
+    [DataRow("event System.Action @event;", Modifier.Private, DisplayName = "An event description about an event without a modifier should contain the `private` modifier")]
+    [DataRow("private event System.Action @event;", Modifier.Private, DisplayName = "An event description about a `private` event should contain the `private` modifier")]
+    [DataRow("public event System.Action @event;", Modifier.Public, DisplayName = "An event description about a `public` event should contain the `public` modifier")]
+    [DataRow("protected event System.Action @event;", Modifier.Protected, DisplayName = "An event description about a `protected` event should contain the `protected` modifier")]
+    [DataRow("internal event System.Action @event;", Modifier.Internal, DisplayName = "An event description about an `internal` event should contain the `internal` modifier")]
+    [DataRow("protected internal event System.Action @event;", Modifier.Protected | Modifier.Internal, DisplayName = "An event description about a `protected internal` event should contain the `protected` and `internal` modifiers")]
+    [DataRow("private protected event System.Action @event;", Modifier.Private | Modifier.Protected, DisplayName = "An event description about a `private protected` event should contain the `private` and `protected` modifiers")]
     [TestMethod]
-    public void EventDeclaration_Should_CreateEventDescription()
+    public void EventsShouldHaveTheCorrectAccessModifiers(string @event, Modifier modifier)
     {
         // Assign
-        var source = @"
+        var source = @$"
         class Test
-        {
-            event System.Action @event;
-
-            Test() { @event(); }
-        }
+        {{
+            {@event}
+        }}
         ";
 
         // Act
-        var types = TestHelper.VisitSyntaxTree(source);
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
 
         // Assert
-        types[0].Events.Should().HaveCount(1);
+        types[0].Events[0].Modifiers.Should().Be(modifier);
     }
 
     [TestMethod]
-    public void EventDeclaration_Should_CreateEventDescriptionTests2()
+    [DataRow("public abstract event System.Action @event;", Modifier.Abstract, DisplayName = "An event description about an `abstract` event should contain the `abstract` modifier")]
+    [DataRow("extern event System.Action @event;", Modifier.Extern, DisplayName = "An event description about an `extern` event should contain the `extern` modifier")]
+    [DataRow("new event System.Action EventB;", Modifier.New, DisplayName = "An event description about a `new` event should contain the `new` modifier")]
+    [DataRow("protected override event System.Action EventB;", Modifier.Override, DisplayName = "An event description about an `override` event should contain the `override` modifier")]
+    [DataRow("sealed protected override event System.Action EventB;", Modifier.Sealed, DisplayName = "An event description about a `sealed` event should contain the `sealed` modifier")]
+    [DataRow("static event System.Action @event;", Modifier.Static, DisplayName = "An event description about a `static` event should contain the `static` modifier")]
+    [DataRow("unsafe event System.Action @event;", Modifier.Unsafe, DisplayName = "An event description about an `unsafe` event should contain the `unsafe` modifier")]
+    [DataRow("protected virtual event System.Action @event;", Modifier.Virtual, DisplayName = "An event description about a `virtual` event should contain the `virtual` modifier")]
+    public void EventsShouldHaveTheCorrectModifiers(string @event, Modifier modifier)
     {
         // Assign
-        var source = @"
-        class Test
-        {
-            event System.Action @event;
-
-            Test() { @event(); }
-        }
+        var source = @$"
+        abstract partial class Test : ClassB
+        {{
+            {@event}
+        }}
+        abstract class ClassB {{
+            protected virtual event System.Action EventB;
+        }}
         ";
 
         // Act
-        var types = TestHelper.VisitSyntaxTree(source);
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067", "CS0626", "CS1998");
 
         // Assert
-        types[0].Events.Should().HaveCount(1);
+        types[0].Events[0].Modifiers.Should().HaveFlag(modifier);
     }
 
     [TestMethod]
-    public void MultipleEventDeclaration_Should_CreateEventDescriptionPerEvent()
+    public void MultipleEventDeclarationsShouldCreateAnEventDescriptionPerEvent()
     {
         // Assign
         var source = @"
         class Test
         {
             event System.Action event1, event2;
+        }
+        ";
 
-            Test() { event1(); event2(); }
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
+
+        // Assert
+        types[0].Events.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void EventDeclaredWithAnInitialValueShouldBeRecognizedAndParsed()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
+            event System.Action @event = () => {};
         }
         ";
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
-
+        
         // Assert
-        types[0].Events.Should().HaveCount(2);
+        types[0].Events[0].HasInitializer.Should().BeTrue();
+        types[0].Events[0].Initializer.Should().Be("() => {}");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/EventDeclarationTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/EventDeclarationTests.cs
@@ -1,69 +1,65 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class EventDeclarationTests
 {
-    [TestClass]
-    public class EventDeclarationTests
+    [TestMethod]
+    public void EventDeclaration_Should_CreateEventDescription()
     {
-        [TestMethod]
-        public void EventDeclaration_Should_CreateEventDescription()
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                event System.Action @event;
+            event System.Action @event;
 
-                Test() { @event(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Events.Should().HaveCount(1);
+            Test() { @event(); }
         }
+        ";
 
-        [TestMethod]
-        public void EventDeclaration_Should_CreateEventDescriptionTests2()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Events.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void EventDeclaration_Should_CreateEventDescriptionTests2()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                event System.Action @event;
+            event System.Action @event;
 
-                Test() { @event(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Events.Should().HaveCount(1);
+            Test() { @event(); }
         }
+        ";
 
-        [TestMethod]
-        public void MultipleEventDeclaration_Should_CreateEventDescriptionPerEvent()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Events.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void MultipleEventDeclaration_Should_CreateEventDescriptionPerEvent()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                event System.Action event1, event2;
+            event System.Action event1, event2;
 
-                Test() { event1(); event2(); }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Events.Should().HaveCount(2);
+            Test() { event1(); event2(); }
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Events.Should().HaveCount(2);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/FieldDeclarationTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/FieldDeclarationTests.cs
@@ -1,45 +1,41 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class FieldDeclarationTests
 {
-    [TestClass]
-    public class FieldDeclarationTests
+    [TestMethod]
+    public void FieldDeclaration_Should_CreateFieldDescription()
     {
-        [TestMethod]
-        public void FieldDeclaration_Should_CreateFieldDescription()
+        // Assign
+        var source = @"
+        public class Test
         {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                public string field;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Fields.Should().HaveCount(1);
+            public string field;
         }
+        ";
 
-        [TestMethod]
-        public void MultipleFieldDeclaration_Should_CreateFieldDescriptionPerField()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void MultipleFieldDeclaration_Should_CreateFieldDescriptionPerField()
+    {
+        // Assign
+        var source = @"
+        public class Test
         {
-            // Assign
-            var source = @"
-            public class Test
-            {
-                public string field1, field2;
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Fields.Should().HaveCount(2);
+            public string field1, field2;
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields.Should().HaveCount(2);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/FieldDeclarationTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/FieldDeclarationTests.cs
@@ -3,26 +3,53 @@ namespace LivingDocumentation.Analyzer.Tests;
 [TestClass]
 public class FieldDeclarationTests
 {
+    [DataRow("string field;", Modifier.Private, DisplayName = "A field description about a field without a modifier should contain the `private` modifier")]
+    [DataRow("private string field;", Modifier.Private, DisplayName = "A field description about a `private` field should contain the `private` modifier")]
+    [DataRow("public string field;", Modifier.Public, DisplayName = "A field description about a `public` field should contain the `public` modifier")]
+    [DataRow("protected string field;", Modifier.Protected, DisplayName = "A field description about a `protected` field should contain the `protected` modifier")]
+    [DataRow("internal string field = default;", Modifier.Internal, DisplayName = "A field description about a `internal` field should contain the `internal` modifier")]
+    [DataRow("protected internal string field;", Modifier.Protected | Modifier.Internal, DisplayName = "A field description about a `protected internal` field should contain the `protected` and `internal` modifiers")]
+    [DataRow("private protected string field;", Modifier.Private | Modifier.Protected, DisplayName = "A field description about a `private protected` field should contain the `private` and `protected` modifiers")]
     [TestMethod]
-    public void FieldDeclaration_Should_CreateFieldDescription()
+    public void FieldsShouldHaveTheCorrectAccessModifiers(string field, Modifier modifier)
     {
         // Assign
-        var source = @"
+        var source = @$"
         public class Test
-        {
-            public string field;
-        }
+        {{
+            {field}
+        }}
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0169");
+
+        // Assert
+        types[0].Fields[0].Modifiers.Should().Be(modifier);
+    }
+
+    [TestMethod]
+    [DataRow("public static string field;", Modifier.Static, DisplayName = "A field description about a `static` field should contain the `static` modifier")]
+    [DataRow("public unsafe string field;", Modifier.Unsafe, DisplayName = "A field description about an `unsafe` field should contain the `unsafe` modifier")]
+    public void FieldsShouldHaveTheCorrectModifiers(string method, Modifier modifier)
+    {
+        // Assign
+        var source = @$"
+        public class Test
+        {{
+            {method}
+        }}
         ";
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
 
         // Assert
-        types[0].Fields.Should().HaveCount(1);
+        types[0].Fields[0].Modifiers.Should().HaveFlag(modifier);
     }
 
     [TestMethod]
-    public void MultipleFieldDeclaration_Should_CreateFieldDescriptionPerField()
+    public void MultipleFieldDeclarationsShouldCreateAFieldDescriptionPerField()
     {
         // Assign
         var source = @"
@@ -37,5 +64,43 @@ public class FieldDeclarationTests
 
         // Assert
         types[0].Fields.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void AFieldDeclarationWithAnInitializerShouldBeRecognizedAndParsed()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
+            public string field1 = ""value"";
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields[0].HasInitializer.Should().BeTrue();
+        types[0].Fields[0].Initializer.Should().Be("value");
+    }
+
+    [TestMethod]
+    public void AFieldInitializedWithAConstantShouldBeResolvedToTheActualConstValue()
+    {
+        // Assign
+        var source = @"
+        public class Test
+        {
+            private const string CONST = ""value"";
+            public string field1 = CONST;
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Fields[0].Initializer.Should().Be("value");
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/ForEachTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/ForEachTests.cs
@@ -1,59 +1,55 @@
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class ForEachTests
 {
-    [TestClass]
-    public class ForEachTests
+    [TestMethod]
+    public void ForEach_Should_BeDetected()
     {
-        [TestMethod]
-        public void ForEach_Should_BeDetected()
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
+            void Method()
             {
-                void Method()
+                var items = new string[0];
+                foreach (var item in items)
                 {
-                    var items = new string[0];
-                    foreach (var item in items)
-                    {
-                    }
                 }
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Statements[0].Should().BeOfType<ForEach>();
         }
+        ";
 
-        [TestMethod]
-        public void ForEachStatements_Should_BeParsed()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Statements[0].Should().BeOfType<ForEach>();
+    }
+
+    [TestMethod]
+    public void ForEachStatements_Should_BeParsed()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
+            void Method()
             {
-                void Method()
+                var items = new string[0];
+                foreach (var item in items)
                 {
-                    var items = new string[0];
-                    foreach (var item in items)
-                    {
-                        var o = new System.Object();
-                    }
+                    var o = new System.Object();
                 }
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            var forEach = types[0].Methods[0].Statements[0];
-            forEach.Statements.Should().HaveCount(1);
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        var forEach = types[0].Methods[0].Statements[0];
+        forEach.Statements.Should().HaveCount(1);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/LivingDocumentation.Analyzer.Tests.csproj
+++ b/tests/LivingDocumentation.Analyzer.Tests/LivingDocumentation.Analyzer.Tests.csproj
@@ -3,17 +3,25 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
 
+    <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <Using Include="FluentAssertions" />
+    <Using Include="FluentAssertions.Execution" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.1">
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/LivingDocumentation.Analyzer.Tests/MethodModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/MethodModifierTests.cs
@@ -3,93 +3,59 @@ namespace LivingDocumentation.Analyzer.Tests;
 [TestClass]
 public class MethodModifierTests
 {
+    [DataRow("void Method() {}", Modifier.Private, DisplayName = "A method description about a method without a modifier should contain the `private` modifier")]
+    [DataRow("private void Method() {}", Modifier.Private, DisplayName = "A method description about a `private` method should contain the `private` modifier")]
+    [DataRow("public void Method() {}", Modifier.Public, DisplayName = "A method description about a `public` method should contain the `public` modifier")]
+    [DataRow("protected void Method() {}", Modifier.Protected, DisplayName = "A method description about a `protected` method should contain the `protected` modifier")]
+    [DataRow("internal void Method() {}", Modifier.Internal, DisplayName = "A method description about a `internal` method should contain the `internal` modifier")]
+    [DataRow("protected internal void Method() {}", Modifier.Protected | Modifier.Internal, DisplayName = "A method description about a `protected internal` method should contain the `protected` and `internal` modifiers")]
+    [DataRow("private protected void Method() {}", Modifier.Private | Modifier.Protected, DisplayName = "A method description about a `private protected` method should contain the `private` and `protected` modifiers")]
     [TestMethod]
-    public void MethodWithoutModifier_Should_HaveDefaultPrivateModifier()
+    public void MethodsShouldHaveTheCorrectAccessModifiers(string method, Modifier modifier)
     {
         // Assign
-        var source = @"
+        var source = @$"
         class Test
-        {
-            void Method() {}
-        }
+        {{
+            {method}
+        }}
         ";
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
 
         // Assert
-        types[0].Methods[0].Modifiers.Should().Be(Modifier.Private);
+        types[0].Methods[0].Modifiers.Should().Be(modifier);
     }
 
     [TestMethod]
-    public void PublicMethod_Should_HavePublicModifier()
+    [DataRow("public abstract void Method();", Modifier.Abstract, DisplayName = "A method description about an `abstract` method should contain the `abstract` modifier")]
+    [DataRow("async void Method() {}", Modifier.Async, DisplayName = "A method description about an `async` method should contain the `async` modifier")]
+    [DataRow("extern void Method();", Modifier.Extern, DisplayName = "A method description about an `extern` method should contain the `extern` modifier")]
+    [DataRow("new void MethodB() {}", Modifier.New, DisplayName = "A method description about a `new` method should contain the `new` modifier")]
+    [DataRow("partial void Method();", Modifier.Partial, DisplayName = "A method description about a `partial` method should contain the `partial` modifier")]
+    [DataRow("protected override void MethodB() {}", Modifier.Override, DisplayName = "A method description about an `override` method should contain the `override` modifier")]
+    [DataRow("sealed protected override void MethodB() {}", Modifier.Sealed, DisplayName = "A method description about a `sealed` method should contain the `sealed` modifier")]
+    [DataRow("static void Method() {}", Modifier.Static, DisplayName = "A method description about a `static` method should contain the `static` modifier")]
+    [DataRow("unsafe void Method() {}", Modifier.Unsafe, DisplayName = "A method description about an `unsafe` method should contain the `unsafe` modifier")]
+    [DataRow("protected virtual void Method() {}", Modifier.Virtual, DisplayName = "A method description about a `virtual` method should contain the `virtual` modifier")]
+    public void MethodsShouldHaveTheCorrectModifiers(string method, Modifier modifier)
     {
         // Assign
-        var source = @"
-        class Test
-        {
-            public void Method() {}
-        }
+        var source = @$"
+        abstract partial class Test : ClassB
+        {{
+            {method}
+        }}
+        abstract class ClassB {{
+            protected virtual void MethodB() {{}}
+        }}
         ";
 
         // Act
-        var types = TestHelper.VisitSyntaxTree(source);
+        var types = TestHelper.VisitSyntaxTree(source, "CS0626", "CS1998");
 
         // Assert
-        types[0].Methods[0].Modifiers.Should().Be(Modifier.Public);
-    }
-
-    [TestMethod]
-    public void StaticMethod_Should_HaveStaticModifier()
-    {
-        // Assign
-        var source = @"
-        class Test
-        {
-            static void Method() {}
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[0].Methods[0].Modifiers.Should().HaveFlag(Modifier.Static);
-    }
-
-    [TestMethod]
-    public void ProtectedMethod_Should_HaveProtectedModifier()
-    {
-        // Assign
-        var source = @"
-        class Test
-        {
-            protected void Method() {}
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[0].Methods[0].Modifiers.Should().Be(Modifier.Protected);
-    }
-
-    [TestMethod]
-    public void InternalMethod_Should_HaveInternalModifier()
-    {
-        // Assign
-        var source = @"
-        class Test
-        {
-            internal void Method() {}
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[0].Methods[0].Modifiers.Should().Be(Modifier.Internal);
+        types[0].Methods[0].Modifiers.Should().HaveFlag(modifier);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/MethodModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/MethodModifierTests.cs
@@ -1,99 +1,95 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class MethodModifierTests
 {
-    [TestClass]
-    public class MethodModifierTests
+    [TestMethod]
+    public void MethodWithoutModifier_Should_HaveDefaultPrivateModifier()
     {
-        [TestMethod]
-        public void MethodWithoutModifier_Should_HaveDefaultPrivateModifier()
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Modifiers.Should().Be(Modifier.Private);
+            void Method() {}
         }
+        ";
 
-        [TestMethod]
-        public void PublicMethod_Should_HavePublicModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Modifiers.Should().Be(Modifier.Private);
+    }
+
+    [TestMethod]
+    public void PublicMethod_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                public void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Modifiers.Should().Be(Modifier.Public);
+            public void Method() {}
         }
+        ";
 
-        [TestMethod]
-        public void StaticMethod_Should_HaveStaticModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Modifiers.Should().Be(Modifier.Public);
+    }
+
+    [TestMethod]
+    public void StaticMethod_Should_HaveStaticModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                static void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Modifiers.Should().HaveFlag(Modifier.Static);
+            static void Method() {}
         }
+        ";
 
-        [TestMethod]
-        public void ProtectedMethod_Should_HaveProtectedModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Modifiers.Should().HaveFlag(Modifier.Static);
+    }
+
+    [TestMethod]
+    public void ProtectedMethod_Should_HaveProtectedModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                protected void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Modifiers.Should().Be(Modifier.Protected);
+            protected void Method() {}
         }
+        ";
 
-        [TestMethod]
-        public void InternalMethod_Should_HaveInternalModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Modifiers.Should().Be(Modifier.Protected);
+    }
+
+    [TestMethod]
+    public void InternalMethod_Should_HaveInternalModifier()
+    {
+        // Assign
+        var source = @"
+        class Test
         {
-            // Assign
-            var source = @"
-            class Test
-            {
-                internal void Method() {}
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Methods[0].Modifiers.Should().Be(Modifier.Internal);
+            internal void Method() {}
         }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Methods[0].Modifiers.Should().Be(Modifier.Internal);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/PartialClassTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/PartialClassTests.cs
@@ -4,16 +4,18 @@ namespace LivingDocumentation.Analyzer.Tests;
 public class PartialClassTests
 {
     [TestMethod]
-    public void ClassWithParts_Should_HaveSingleEntry()
+    public void PartialClassesShouldBecomeASingleType()
     {
         // Assign
         var source = @"
         partial class Test
         {
+            public string Property1 { get; }
         }
 
         partial class Test
         {
+            public string Property2 { get; }
         }
         ";
 
@@ -25,7 +27,7 @@ public class PartialClassTests
     }
 
     [TestMethod]
-    public void ClassWithParts_Should_HaveCombinedProperties()
+    public void MembersOfPartialClassesShouldBeCombined()
     {
         // Assign
         var source = @"
@@ -46,5 +48,4 @@ public class PartialClassTests
         // Assert
         types[0].Properties.Should().HaveCount(2);
     }
-
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/PartialClassTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/PartialClassTests.cs
@@ -1,57 +1,50 @@
-﻿using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class PartialClassTests
 {
-    [TestClass]
-    public class PartialClassTests
+    [TestMethod]
+    public void ClassWithParts_Should_HaveSingleEntry()
     {
-        [TestMethod]
-        public void ClassWithParts_Should_HaveSingleEntry()
+        // Assign
+        var source = @"
+        partial class Test
         {
-            // Assign
-            var source = @"
-            partial class Test
-            {
-            }
-
-            partial class Test
-            {
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types.Should().HaveCount(1);
         }
 
-        [TestMethod]
-        public void ClassWithParts_Should_HaveCombinedProperties()
+        partial class Test
         {
-            // Assign
-            var source = @"
-            partial class Test
-            {
-                public string Property1 { get; }
-            }
-
-            partial class Test
-            {
-                public string Property2 { get; }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Properties.Should().HaveCount(2);
         }
+        ";
 
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types.Should().HaveCount(1);
     }
+
+    [TestMethod]
+    public void ClassWithParts_Should_HaveCombinedProperties()
+    {
+        // Assign
+        var source = @"
+        partial class Test
+        {
+            public string Property1 { get; }
+        }
+
+        partial class Test
+        {
+            public string Property2 { get; }
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Properties.Should().HaveCount(2);
+    }
+
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/RecordModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/RecordModifierTests.cs
@@ -1,0 +1,110 @@
+namespace LivingDocumentation.Analyzer.Tests;
+
+#if NET6_0_OR_GREATER
+
+[TestClass]
+public class RecordModifierTests
+{
+    [DataRow("record Test();", Modifier.Internal, DisplayName = "A type description about a record without a modifier should contain the `internal` modifier")]
+    [DataRow("public record Test();", Modifier.Public, DisplayName = "A type description about a `public` record should contain the `public` modifier")]
+    [DataRow("internal record Test();", Modifier.Internal, DisplayName = "A type description about an `internal` record should contain the `internal` modifier")]
+    [DataRow("record class Test();", Modifier.Internal, DisplayName = "A type description about a record class without a modifier should contain the `internal` modifier")]
+    [DataRow("public record class Test();", Modifier.Public, DisplayName = "A type description about a `public` record class should contain the `public` modifier")]
+    [DataRow("internal record class Test();", Modifier.Internal, DisplayName = "A type description about an `internal` record class should contain the `internal` modifier")]
+    [DataRow("record struct Test();", Modifier.Internal, DisplayName = "A type description about a record struct without a modifier should contain the `internal` modifier")]
+    [DataRow("public record struct Test();", Modifier.Public, DisplayName = "A type description about a `public` record struct should contain the `public` modifier")]
+    [DataRow("internal record struct Test();", Modifier.Internal, DisplayName = "A type description about an `internal` record struct should contain the `internal` modifier")]
+    [TestMethod]
+    public void RecordsShouldHaveTheCorrectAccessModifiers(string @record, Modifier modifier)
+    {
+        // Assign
+        var source = @record;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(modifier);
+    }
+
+    [TestMethod]
+    [DataRow("abstract record Test {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` record should contain the `abstract` modifier")]
+    [DataRow("unsafe record Test {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` record should contain the `unsafe` modifier")]
+    [DataRow("abstract record class Test {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` record class should contain the `abstract` modifier")]
+    [DataRow("unsafe record class Test {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` record class should contain the `unsafe` modifier")]
+    [DataRow("readonly record struct Test {}", Modifier.Readonly, DisplayName = "A type description about an `readonly` record struct should contain the `readonly` modifier")]
+    [DataRow("unsafe record struct Test {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` record struct should contain the `unsafe` modifier")]
+    public void RecordsShouldHaveTheCorrectModifiers(string @record, Modifier modifier)
+    {
+        // Assign
+        var source = @record;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().HaveFlag(modifier);
+    }
+
+    [DataRow("class NestedTest {}", Modifier.Private, DisplayName = "A type description about a nested class without a modifier should contain the `private` modifier")]
+    [DataRow("private class NestedTest {}", Modifier.Private, DisplayName = "A type description about a `private` nested class should contain the `private` modifier")]
+    [DataRow("public class NestedTest {}", Modifier.Public, DisplayName = "A type description about a `public` nested class should contain the `public` modifier")]
+    [DataRow("protected class NestedTest {}", Modifier.Protected, DisplayName = "A type description about a `protected` nested class should contain the `protected` modifier")]
+    [DataRow("internal class NestedTest {}", Modifier.Internal, DisplayName = "A type description about an `internal` nested class should contain the `internal` modifier")]
+    [DataRow("protected internal class NestedTest {}", Modifier.Protected | Modifier.Internal, DisplayName = "A type description about a `protected internal` nested class should contain the `protected` and `internal` modifiers")]
+    [DataRow("private protected class NestedTest {}", Modifier.Private | Modifier.Protected, DisplayName = "A type description about a `private protected` nested class should contain the `private` and `protected` modifiers")]
+    [TestMethod]
+    public void NestedRecordsShouldHaveTheCorrectAccessModifiers(string @record, Modifier modifier)
+    {
+        // Assign
+        var source = @$"
+        class Test
+        {{
+            {@record}
+        }}
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[1].Modifiers.Should().Be(modifier);
+    }
+
+    [TestMethod]
+    [DataRow("abstract record NestedTest {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` nested record should contain the `abstract` modifier")]
+    [DataRow("new record NestedA {}", Modifier.New, DisplayName = "A type description about a `new` nested record should contain the `new` modifier")]
+    [DataRow("partial record NestedTest {}", Modifier.Partial, DisplayName = "A type description about a `partial` nested record should contain the `partial` modifier")]
+    [DataRow("unsafe record NestedTest {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` nested record should contain the `unsafe` modifier")]
+    [DataRow("abstract record class NestedTest {}", Modifier.Abstract, DisplayName = "A type description about an `abstract` nested record class should contain the `abstract` modifier")]
+    [DataRow("new record class NestedB {}", Modifier.New, DisplayName = "A type description about a `new` nested record class should contain the `new` modifier")]
+    [DataRow("partial record class NestedTest {}", Modifier.Partial, DisplayName = "A type description about a `partial` nested record class should contain the `partial` modifier")]
+    [DataRow("unsafe record class NestedTest {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` nested record class should contain the `unsafe` modifier")]
+    [DataRow("new record struct NestedC {}", Modifier.New, DisplayName = "A type description about a `new` nested record struct should contain the `new` modifier")]
+    [DataRow("partial record struct NestedTest {}", Modifier.Partial, DisplayName = "A type description about a `partial` nested record struct should contain the `partial` modifier")]
+    [DataRow("readonly record struct NestedTest {}", Modifier.Readonly, DisplayName = "A type description about a `readonly` nested record struct should contain the `readonly` modifier")]
+    [DataRow("unsafe record struct NestedTest {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` nested record struct should contain the `unsafe` modifier")]
+    public void NestedRecordsShouldHaveTheCorrectModifiers(string @record, Modifier modifier)
+    {
+        // Assign
+        var source = @$"
+        class Test : ClassB
+        {{
+            {@record}
+        }}
+        class ClassB {{
+            internal record NestedA {{}};
+            internal record class NestedB {{}};
+            internal record struct NestedC {{}};
+        }}
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source, "CS0067");
+
+        // Assert
+        types[1].Modifiers.Should().HaveFlag(modifier);
+    }
+}
+
+#endif

--- a/tests/LivingDocumentation.Analyzer.Tests/StructModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/StructModifierTests.cs
@@ -1,83 +1,79 @@
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace LivingDocumentation.Analyzer.Tests;
 
-namespace LivingDocumentation.Analyzer.Tests
+[TestClass]
+public class StructModifierTests
 {
-    [TestClass]
-    public class StructModifierTests
+    [TestMethod]
+    public void StructWithoutModifier_Should_HaveDefaultInternalModifier()
     {
-        [TestMethod]
-        public void StructWithoutModifier_Should_HaveDefaultInternalModifier()
+        // Assign
+        var source = @"
+        struct Test
         {
-            // Assign
-            var source = @"
-            struct Test
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Internal);
+    }
+
+    [TestMethod]
+    public void PublicStruct_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        public struct Test
+        {
+        }
+        ";
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().Be(Modifier.Public);
+    }
+
+    [TestMethod]
+    public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
+    {
+        // Assign
+        var source = @"
+        struct Test
+        {
+            struct NestedTest
             {
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Internal);
         }
+        ";
 
-        [TestMethod]
-        public void PublicStruct_Should_HavePublicModifier()
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[1].Modifiers.Should().Be(Modifier.Private);
+    }
+
+    [TestMethod]
+    public void NestedPublicStruct_Should_HavePublicModifier()
+    {
+        // Assign
+        var source = @"
+        struct Test
         {
-            // Assign
-            var source = @"
-            public struct Test
+            public struct NestedTest
             {
             }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[0].Modifiers.Should().Be(Modifier.Public);
         }
+        ";
 
-        [TestMethod]
-        public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
-        {
-            // Assign
-            var source = @"
-            struct Test
-            {
-                struct NestedTest
-                {
-                }
-            }
-            ";
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
 
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[1].Modifiers.Should().Be(Modifier.Private);
-        }
-
-        [TestMethod]
-        public void NestedPublicStruct_Should_HavePublicModifier()
-        {
-            // Assign
-            var source = @"
-            struct Test
-            {
-                public struct NestedTest
-                {
-                }
-            }
-            ";
-
-            // Act
-            var types = TestHelper.VisitSyntaxTree(source);
-
-            // Assert
-            types[1].Modifiers.Should().Be(Modifier.Public);
-        }
+        // Assert
+        types[1].Modifiers.Should().Be(Modifier.Public);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/StructModifierTests.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/StructModifierTests.cs
@@ -3,77 +3,77 @@ namespace LivingDocumentation.Analyzer.Tests;
 [TestClass]
 public class StructModifierTests
 {
+    [DataRow("struct Test {}", Modifier.Internal, DisplayName = "A type description about a struct without a modifier should contain the `internal` modifier")]
+    [DataRow("public struct Test {}", Modifier.Public, DisplayName = "A type description about a `public` struct should contain the `public` modifier")]
+    [DataRow("internal struct Test {}", Modifier.Internal, DisplayName = "A type description about an `internal` struct should contain the `internal` modifier")]
     [TestMethod]
-    public void StructWithoutModifier_Should_HaveDefaultInternalModifier()
+    public void StructsShouldHaveTheCorrectAccessModifiers(string @struct, Modifier modifier)
     {
         // Assign
-        var source = @"
-        struct Test
-        {
-        }
-        ";
+        var source = @struct;
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
 
         // Assert
-        types[0].Modifiers.Should().Be(Modifier.Internal);
+        types[0].Modifiers.Should().Be(modifier);
     }
 
     [TestMethod]
-    public void PublicStruct_Should_HavePublicModifier()
+    [DataRow("readonly struct Test {}", Modifier.Readonly, DisplayName = "A type description about a `readonly` class should contain the `readonly` modifier")]
+    [DataRow("unsafe struct Test {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` class should contain the `unsafe` modifier")]
+    public void StructsShouldHaveTheCorrectModifiers(string @struct, Modifier modifier)
     {
         // Assign
-        var source = @"
-        public struct Test
-        {
-        }
+        var source = @struct;
+
+        // Act
+        var types = TestHelper.VisitSyntaxTree(source);
+
+        // Assert
+        types[0].Modifiers.Should().HaveFlag(modifier);
+    }
+    
+    [DataRow("struct NestedTest {}", Modifier.Private, DisplayName = "A type description about a nested struct without a modifier should contain the `private` modifier")]
+    [DataRow("private struct NestedTest {}", Modifier.Private, DisplayName = "A type description about a `private` nested struct should contain the `private` modifier")]
+    [DataRow("public struct NestedTest {}", Modifier.Public, DisplayName = "A type description about a `public` nested struct should contain the `public` modifier")]
+    [DataRow("internal struct NestedTest {}", Modifier.Internal, DisplayName = "A type description about an `internal` nested struct should contain the `internal` modifier")]
+    [TestMethod]
+    public void NestedStructsShouldHaveTheCorrectAccessModifiers(string @struct, Modifier modifier)
+    {
+        // Assign
+        var source = @$"
+        struct Test
+        {{
+            {@struct}
+        }}
         ";
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
 
         // Assert
-        types[0].Modifiers.Should().Be(Modifier.Public);
+        types[1].Modifiers.Should().Be(modifier);
     }
 
     [TestMethod]
-    public void NestedClassWithoutModifier_Should_HaveDefaultPrivateModifier()
+    [DataRow("partial struct NestedTest {}", Modifier.Partial, DisplayName = "A type description about a `partial` nested struct should contain the `partial` modifier")]
+    [DataRow("readonly struct NestedTest {}", Modifier.Readonly, DisplayName = "A type description about a `readonly` nested struct should contain the `readonly` modifier")]
+    [DataRow("unsafe struct NestedTest {}", Modifier.Unsafe, DisplayName = "A type description about an `unsafe` nested class struct contain the `unsafe` modifier")]
+    public void NestedStructsShouldHaveTheCorrectModifiers(string @struct, Modifier modifier)
     {
         // Assign
-        var source = @"
+        var source = @$"
         struct Test
-        {
-            struct NestedTest
-            {
-            }
-        }
+        {{
+            {@struct}
+        }}
         ";
 
         // Act
         var types = TestHelper.VisitSyntaxTree(source);
 
         // Assert
-        types[1].Modifiers.Should().Be(Modifier.Private);
-    }
-
-    [TestMethod]
-    public void NestedPublicStruct_Should_HavePublicModifier()
-    {
-        // Assign
-        var source = @"
-        struct Test
-        {
-            public struct NestedTest
-            {
-            }
-        }
-        ";
-
-        // Act
-        var types = TestHelper.VisitSyntaxTree(source);
-
-        // Assert
-        types[1].Modifiers.Should().Be(Modifier.Public);
+        types[1].Modifiers.Should().HaveFlag(modifier);
     }
 }

--- a/tests/LivingDocumentation.Analyzer.Tests/TestHelper.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/TestHelper.cs
@@ -11,7 +11,10 @@ internal class TestHelper
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source.Trim());
         var compilation = CSharpCompilation.Create("Test")
-                                            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                            .WithOptions(
+                                                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                                                    .WithAllowUnsafe(true)
+                                            )
                                             .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
                                             .AddSyntaxTrees(syntaxTree);
 

--- a/tests/LivingDocumentation.Analyzer.Tests/TestHelper.cs
+++ b/tests/LivingDocumentation.Analyzer.Tests/TestHelper.cs
@@ -1,35 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace LivingDocumentation.Analyzer.Tests
+namespace LivingDocumentation.Analyzer.Tests;
+ 
+internal class TestHelper
 {
-    internal class TestHelper
+    public static IReadOnlyList<TypeDescription> VisitSyntaxTree(string source, params string[] ignoreErrorCodes)
     {
-        public static IReadOnlyList<TypeDescription> VisitSyntaxTree(string source, params string[] ignoreErrorCodes)
-        {
-            source.Should().NotBeNullOrWhiteSpace("without source code there is nothing to test");
+        source.Should().NotBeNullOrWhiteSpace("without source code there is nothing to test");
 
-            var syntaxTree = CSharpSyntaxTree.ParseText(source.Trim());
-            var compilation = CSharpCompilation.Create("Test")
-                                               .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-                                               .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
-                                               .AddSyntaxTrees(syntaxTree);
+        var syntaxTree = CSharpSyntaxTree.ParseText(source.Trim());
+        var compilation = CSharpCompilation.Create("Test")
+                                            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+                                            .AddSyntaxTrees(syntaxTree);
 
-            var diagnostics = compilation.GetDiagnostics().Where(d => !ignoreErrorCodes.Contains(d.Id));
-            diagnostics.Should().HaveCount(0, "there shoudn't be any compile errors");
+        var diagnostics = compilation.GetDiagnostics().Where(d => !ignoreErrorCodes.Contains(d.Id));
+        diagnostics.Should().HaveCount(0, "there shoudn't be any compile errors");
 
-            var semanticModel = compilation.GetSemanticModel(syntaxTree, true);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree, true);
 
-            var types = new List<TypeDescription>();
+        var types = new List<TypeDescription>();
 
-            var visitor = new SourceAnalyzer(semanticModel, types);
-            visitor.Visit(syntaxTree.GetRoot());
+        var visitor = new SourceAnalyzer(semanticModel, types);
+        visitor.Visit(syntaxTree.GetRoot());
 
-            return types;
-        }
+        return types;
     }
 }

--- a/tests/LivingDocumentation.RenderExtensions.Tests/LivingDocumentation.RenderExtensions.Tests.csproj
+++ b/tests/LivingDocumentation.RenderExtensions.Tests/LivingDocumentation.RenderExtensions.Tests.csproj
@@ -1,18 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
+
+    <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <Using Include="FluentAssertions" />
+    <Using Include="FluentAssertions.Execution" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.1">
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/LivingDocumentation.Serializations.Tests/DeserializationTests.cs
+++ b/tests/LivingDocumentation.Serializations.Tests/DeserializationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,7 +23,7 @@ namespace LivingDocumentation.Analyzer.Tests
         }
 
         [TestMethod]
-        public void OnlyFullName_Should_GiveInternalClass()
+        public void AClassWithoutAModifierShouldBeInternalByDefault()
         {
             // Assign
             var json = @"[{""FullName"":""Test""}]";
@@ -57,21 +57,38 @@ namespace LivingDocumentation.Analyzer.Tests
             types[0].Events.Should().BeEmpty();
         }
 
+        [DataRow(00_001, Modifier.Internal, DisplayName = "A serialized value of `1` should be parsed as an `internal` modifier")]
+        [DataRow(00_002, Modifier.Public, DisplayName = "A serialized value of `2` should be parsed as a `public` modifier")]
+        [DataRow(00_004, Modifier.Private, DisplayName = "A serialized value of `4` should be parsed as a `private` modifier")]
+        [DataRow(00_008, Modifier.Protected, DisplayName = "A serialized value of `8` should be parsed as a `protected` modifier")]
+        [DataRow(00_012, Modifier.Private | Modifier.Protected, DisplayName = "A serialized value of `12` should be parsed as a `private` and `protected` modifier")]
+        [DataRow(00_016, Modifier.Static, DisplayName = "A serialized value of `16` should be parsed as a `static` modifier")]
+        [DataRow(00_032, Modifier.Abstract, DisplayName = "A serialized value of `32` should be parsed as an `abstract` modifier")]
+        [DataRow(00_064, Modifier.Override, DisplayName = "A serialized value of `64` should be parsed as an `override` modifier")]
+        [DataRow(00_128, Modifier.Readonly, DisplayName = "A serialized value of `128` should be parsed as a `readonly` modifier")]
+        [DataRow(00_256, Modifier.Async, DisplayName = "A serialized value of `256` should be parsed as an `async` modifier")]
+        [DataRow(00_512, Modifier.Const, DisplayName = "A serialized value of `512` should be parsed as a `const` modifier")]
+        [DataRow(01_024, Modifier.Sealed, DisplayName = "A serialized value of `1024` should be parsed as a `sealed` modifier")]
+        [DataRow(02_048, Modifier.Virtual, DisplayName = "A serialized value of `2048` should be parsed as a `virtual` modifier")]
+        [DataRow(04_096, Modifier.Extern, DisplayName = "A serialized value of `4096` should be parsed as an `extern` modifier")]
+        [DataRow(08_192, Modifier.New, DisplayName = "A serialized value of `8192` should be parsed as a `new` modifier")]
+        [DataRow(16_384, Modifier.Unsafe, DisplayName = "A serialized value of `16384` should be parsed as an `unsafe` modifier")]
+        [DataRow(32_768, Modifier.Partial, DisplayName = "A serialized value of `32768` should be parsed as a `partial` modifier")]
         [TestMethod]
-        public void Modifiers2_Should_GivePublicClass()
+        public void ModifiersShouldBeDeserializedCorrectly(int value, Modifier modifier)
         {
             // Assign
-            var json = @"[{""Modifiers"":2,""FullName"":""Test""}]";
+            var json = @$"[{{""Modifiers"":{value},""FullName"":""Test""}}]";
 
             // Act
             var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
 
             // Assert
-            types[0].Modifiers.Should().Be(Modifier.Public);
+            types[0].Modifiers.Should().Be(modifier);
         }
 
         [TestMethod]
-        public void MethodsCollection_Should_GivePrivateMethod()
+        public void MembersOfAClassWithoutAModifierShouldBePrivateByDefault()
         {
             // Assign
             var json = @"[{""FullName"":""Test"",""Methods"":[{""Name"":""Method""}]}]";
@@ -117,6 +134,217 @@ namespace LivingDocumentation.Analyzer.Tests
             types[0].Attributes[0].Arguments[0].Type.Should().Be("string");
             types[0].Attributes[0].Arguments[0].Name.Should().Be(@"""Reason""");
             types[0].Attributes[0].Arguments[0].Value.Should().Be(@"Reason");
+        }
+
+        [TestMethod]
+        public void AStatementInAMethodBodyShouldHaveTheMethodAsParent()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"":""LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions"",
+                        ""ContainingType"": ""Test"",
+                        ""Name"": ""TestMethod""
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Parent.Should().Be(types[0].Methods[0]);
+        }
+
+        [TestMethod]
+        public void AnIfElseSectionShouldHaveTheIfAsParent()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.If, LivingDocumentation.Statements"",
+                        ""Sections"":[{}]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<If>();
+
+            var @if = (If)types[0].Methods[0].Statements[0];
+            @if.Sections[0].Parent.Should().Be(@if);
+        }
+
+        [TestMethod]
+        public void AnIfElseConditionShouldBeParsedCorrectly()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.If, LivingDocumentation.Statements"",
+                        ""Sections"":[{""Condition"": ""true""}]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<If>();
+
+            var @if = (If)types[0].Methods[0].Statements[0];
+            @if.Sections[0].Condition.Should().Be("true");
+        }[TestMethod]
+        public void AStatementInAnIfElseSectionShouldHaveTheIfElseSectionAsParent()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.If, LivingDocumentation.Statements"",
+                        ""Sections"":[{
+                            ""Statements"":[{
+                                ""$type"":""LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions"",
+                                ""ContainingType"": ""Test"",
+                                ""Name"": ""TestMethod""
+                            }]
+                        }]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<If>();
+
+            var @if = (If)types[0].Methods[0].Statements[0];
+            @if.Sections[0].Statements[0].Parent.Should().Be(@if.Sections[0]);
+        }
+
+        [TestMethod]
+        public void ASwitchSectionShouldHaveTheSwitchAsParent()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.Switch, LivingDocumentation.Statements"",
+                        ""Sections"":[{}]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<Switch>();
+
+            var @switch = (Switch)types[0].Methods[0].Statements[0];
+            @switch.Sections[0].Parent.Should().Be(@switch);
+        }
+
+        [TestMethod]
+        public void ASwitchExpressionShouldBeParsedCorrectly()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.Switch, LivingDocumentation.Statements"",
+                        ""Expression"":""type""
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<Switch>();
+
+            var @switch = (Switch)types[0].Methods[0].Statements[0];
+            @switch.Expression.Should().Be("type");
+        }
+
+        [TestMethod]
+        public void SwitchLabelsShouldBeParsedCorrectly()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.Switch, LivingDocumentation.Statements"",
+                        ""Sections"":[{
+                            ""Labels"": [""System.String""]
+                        }]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<Switch>();
+
+            var @switch = (Switch)types[0].Methods[0].Statements[0];
+            @switch.Sections[0].Labels.Should().HaveCount(1);
+            @switch.Sections[0].Labels.Should().Contain("System.String");
+        }
+
+        [TestMethod]
+        public void AStatementInASwitchSectionShouldHaveTheSwitchSectionAsParent()
+        {
+            // Assign
+            var json = @"[{
+                ""FullName"":""Test"",
+                ""Methods"":[{
+                    ""Name"":""Method"",
+                    ""Statements"":[{
+                        ""$type"": ""LivingDocumentation.Switch, LivingDocumentation.Statements"",
+                        ""Sections"":[{
+                            ""Statements"":[{
+                                ""$type"":""LivingDocumentation.InvocationDescription, LivingDocumentation.Descriptions"",
+                                ""ContainingType"": ""Test"",
+                                ""Name"": ""TestMethod""
+                            }]
+                        }]
+                    }]
+                }]
+            }]";
+
+            // Act
+            var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings());
+
+            // Assert
+            types[0].Methods[0].Statements[0].Should().BeOfType<Switch>();
+
+            var @switch = (Switch)types[0].Methods[0].Statements[0];
+            @switch.Sections[0].Statements[0].Parent.Should().Be(@switch.Sections[0]);
         }
     }
 }

--- a/tests/LivingDocumentation.Serializations.Tests/LivingDocumentation.Serializations.Tests.csproj
+++ b/tests/LivingDocumentation.Serializations.Tests/LivingDocumentation.Serializations.Tests.csproj
@@ -3,17 +3,25 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
 
+    <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <Using Include="FluentAssertions" />
+    <Using Include="FluentAssertions.Execution" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.1">
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/LivingDocumentation.Serializations.Tests/SerializationTests.cs
+++ b/tests/LivingDocumentation.Serializations.Tests/SerializationTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
@@ -119,7 +119,7 @@ namespace LivingDocumentation.Analyzer.Tests
             var result = JsonConvert.SerializeObject(types, JsonDefaults.SerializerSettings());
 
             // Assert
-            result.Should().Match(@"[{""FullName"":""Test"",""Attributes"":[{""Type"":""System.ObsoleteAttribute"",""Name"":""System.Obsolete"",""Arguments"":[{""Name"":""\""Reason\"""",""Type"":""string"",""Value"":""Reason""}]}]}]");
+            result.Should().Match(@"[{""FullName"":""Test"",""Attributes"":[{""Type"":""System.ObsoleteAttribute"",""Name"":""System.Obsolete"",""Arguments"":[{""Name"":""Reason"",""Type"":""string"",""Value"":""Reason""}]}]}]");
         }
     }
 }

--- a/tests/LivingDocumentation.Uml.Tests/LivingDocumentation.UML.Tests.csproj
+++ b/tests/LivingDocumentation.Uml.Tests/LivingDocumentation.UML.Tests.csproj
@@ -1,19 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
     <RootNamespace>LivingDocumentation.Uml.Tests</RootNamespace>
+
+    <ImplicitUsings>true</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <Using Include="FluentAssertions" />
+    <Using Include="FluentAssertions.Execution" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.1">
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="coverlet.collector" Version="3.1.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
* Add support for `const`, `sealed`, `virtual`, `extern`, `new`, `unsafe`, and `partial` as modifiers
* Resolve constant value if possible.
* Format `string` concatenation and multiline `array`, `object` and `dictionary` initialization to a single line
* Apply expression resolving & formatting to more places
* C# lay-out improvements
* Improved `null`able notations/handling